### PR TITLE
- DryRun enhacement for topics creation/update

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -126,10 +126,9 @@ You can also create your own custom validations. The validations must implement 
 - com.purbon.kafka.topology.validation.TopologyValidation
 - com.purbon.kafka.topology.validation.TopicValidation
 
-Topic overwrite / Update Option and dryrun output
+Dryrun output for topics
 -----------
-Regularly when julie applies changes to existing topics it will always overwrite all* the configuration keys with the existing ones. Also, the output of the dryrun will print all (un)changed properties.
-With this option, this can be configured. Only the changed topics and values will be shown in the -dryrun log with the following format. Apart from that, it will also only change the keys which were updated via the KafkaAdminClient.
+When the --dryRun option is specified then only the changed topics and values will be shown in the log for the topics with the following format.
 
 ::
 {
@@ -159,10 +158,6 @@ Legend
 
 Note: num.partitions, replication.factor will never be part of the update as this needs to be applied differently.
 
-An example configuration to only update changed configuration and output it in the dryrun.
-::
-    topology.topic.sync.overwrite: false
-**Default value**: true
 
 Prevent ACL for topic creation for connector principal
 -----------

--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -126,6 +126,44 @@ You can also create your own custom validations. The validations must implement 
 - com.purbon.kafka.topology.validation.TopologyValidation
 - com.purbon.kafka.topology.validation.TopicValidation
 
+Topic overwrite / Update Option and dryrun output
+-----------
+Regularly when julie applies changes to existing topics it will always overwrite all* the configuration keys with the existing ones. Also, the output of the dryrun will print all (un)changed properties.
+With this option, this can be configured. Only the changed topics and values will be shown in the -dryrun log with the following format. Apart from that, it will also only change the keys which were updated via the KafkaAdminClient.
+
+::
+{
+  "Operation" : "com.purbon.kafka.topology.actions.topics.SyncTopicAction",
+  "Topic" : "project.test-new-topic.a0",
+  "Action" : "create",
+  "Changes" : {
+    "cleanup.policy" : "[Set] delete",
+    "min.insync.replicas" : "[Set] 3"
+  }
+}
+{
+  "Operation" : "com.purbon.kafka.topology.actions.topics.SyncTopicAction",
+  "Topic" : "project.test-existing-topic.a0",
+  "Action" : "update",
+  "Changes" : {
+    "cleanup.policy" : "[Update] delete -> cleanup",
+    "min.insync.replicas" : "[Update] 2 -> 3",
+    "retention.ms" : "[Unset] 2592000000 ->  "
+  }
+}
+
+Legend
+[Set] config entry is new
+[Unset] config entry is removed
+[Update] config entry is updated
+
+Note: num.partitions, replication.factor will never be part of the update as this needs to be applied differently.
+
+An example configuration to only update changed configuration and output it in the dryrun.
+::
+    topology.topic.sync.overwrite: false
+**Default value**: true
+
 Prevent ACL for topic creation for connector principal
 -----------
 

--- a/docs/how-to-run-it.rst
+++ b/docs/how-to-run-it.rst
@@ -26,6 +26,7 @@ If you are using the CLI tool, you an use the *--help* command to list the diffe
           --help                 Prints usage information.
           --quiet                Print minimum status update
           --topology <arg>       Topology config file.
+          --plan <arg>           Plan config file.
           --version              Prints useful version information.
 
 The most important ones are:

--- a/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
+++ b/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
@@ -143,7 +143,7 @@ public class CommandLineInterface {
 
     processTopology(
         cmd.getOptionValue(TOPOLOGY_OPTION), cmd.getOptionValue(PLANS_OPTION, "default"), config);
-    System.out.println("Kafka Topology updated");
+    System.out.println("Kafka Topology finished successfully");
   }
 
   private Map<String, String> parseConfig(CommandLine cmd) {

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -58,6 +58,8 @@ public class Configuration {
   private static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";
   private static final String CONFLUENT_METRICS_TOPIC_CONFIG = "confluent.metrics.topic";
   static final String TOPIC_PREFIX_FORMAT_CONFIG = "topology.topic.prefix.format";
+  static final String TOPIC_SYNC_OVERWRITE_CONFIG = "topology.topic.sync.overwrite";
+
   static final String PROJECT_PREFIX_FORMAT_CONFIG = "topology.project.prefix.format";
   static final String TOPIC_PREFIX_SEPARATOR_CONFIG = "topology.topic.prefix.separator";
   static final String TOPOLOGY_VALIDATIONS_CONFIG = "topology.validations";
@@ -303,6 +305,10 @@ public class Configuration {
 
   public Boolean shouldOptimizeAcls() {
     return config.getBoolean(OPTIMIZED_ACLS_CONFIG);
+  }
+
+  public Boolean shouldOverwriteTopicsInSync() {
+    return config.getBoolean(TOPIC_SYNC_OVERWRITE_CONFIG);
   }
 
   public String getConfluentCloudEnv() {

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -58,7 +58,6 @@ public class Configuration {
   private static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";
   private static final String CONFLUENT_METRICS_TOPIC_CONFIG = "confluent.metrics.topic";
   static final String TOPIC_PREFIX_FORMAT_CONFIG = "topology.topic.prefix.format";
-  static final String TOPIC_SYNC_OVERWRITE_CONFIG = "topology.topic.sync.overwrite";
 
   static final String PROJECT_PREFIX_FORMAT_CONFIG = "topology.project.prefix.format";
   static final String TOPIC_PREFIX_SEPARATOR_CONFIG = "topology.topic.prefix.separator";
@@ -305,10 +304,6 @@ public class Configuration {
 
   public Boolean shouldOptimizeAcls() {
     return config.getBoolean(OPTIMIZED_ACLS_CONFIG);
-  }
-
-  public Boolean shouldOverwriteTopicsInSync() {
-    return config.getBoolean(TOPIC_SYNC_OVERWRITE_CONFIG);
   }
 
   public String getConfluentCloudEnv() {

--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -81,9 +82,12 @@ public class ExecutionPlan {
   }
 
   private void execute(Action action, boolean dryRun) throws IOException {
-    LOGGER.debug(String.format("Execution action %s (dryRun=%s)", action, dryRun));
+    LOGGER.debug("Execution action {} (dryRun={}})", action, dryRun);
     if (dryRun) {
-      outputStream.println(action);
+      String actions = action.toString();
+      if (StringUtils.isNotBlank(actions)) {
+        outputStream.println(actions);
+      }
     } else {
       action.run();
       if (action instanceof SyncTopicAction) {

--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -84,10 +83,7 @@ public class ExecutionPlan {
   private void execute(Action action, boolean dryRun) throws IOException {
     LOGGER.debug("Execution action {} (dryRun={}})", action, dryRun);
     if (dryRun) {
-      String actions = action.toString();
-      if (StringUtils.isNotBlank(actions)) {
-        outputStream.println(actions);
-      }
+      outputStream.println(action);
     } else {
       action.run();
       if (action instanceof SyncTopicAction) {

--- a/src/main/java/com/purbon/kafka/topology/TopicManager.java
+++ b/src/main/java/com/purbon/kafka/topology/TopicManager.java
@@ -54,7 +54,12 @@ public class TopicManager {
         (topicName, topic) -> {
           plan.add(
               new SyncTopicAction(
-                  adminClient, schemaRegistryManager, topic, topicName, listOfTopics));
+                  adminClient,
+                  schemaRegistryManager,
+                  config,
+                  topic,
+                  topicName,
+                  listOfTopics.contains(topicName)));
         });
 
     if (config.allowDelete() || config.isAllowDeleteTopics()) {

--- a/src/main/java/com/purbon/kafka/topology/actions/BaseAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/BaseAction.java
@@ -11,7 +11,11 @@ public abstract class BaseAction implements Action {
   @Override
   public String toString() {
     try {
-      return JSON.asPrettyString(props());
+      Map<String, Object> props = props();
+      if (props != null) {
+        return JSON.asPrettyString(props);
+      }
+      return "";
     } catch (JsonProcessingException e) {
       return "";
     }

--- a/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
@@ -103,8 +103,7 @@ public class SyncTopicAction extends BaseAction {
     if (!changes.isEmpty()) {
       map.put("Action", actionName);
       map.put("Changes", changes);
-      return map;
-    } else if (!config.shouldOverwriteTopicsInSync()) {
+    } else {
       return null;
     }
     return map;

--- a/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
@@ -60,11 +60,11 @@ public class SyncTopicAction extends BaseAction {
         LOGGER.debug("Update partition count of topic {}", fullTopicName);
         adminClient.updatePartitionCount(topic, fullTopicName);
       } else {
-        LOGGER.warn(
+        LOGGER.info(
             "Skipping topic sync for topic {} due to limitation to decrease partition count of existing topic configuration",
             fullTopicName);
       }
-      adminClient.updateTopicConfig(topic, fullTopicName, false);
+      adminClient.updateTopicConfig(topic, fullTopicName, config.isDryRun());
     } else {
       LOGGER.debug("Create new topic with name {}", fullTopicName);
       adminClient.createTopic(topic, fullTopicName);

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
@@ -79,6 +79,18 @@ public class TopologyBuilderAdminClient {
     return listTopics(options);
   }
 
+  /**
+   * Syncs and updates Topic and returns the cluster changed configuration as map with
+   * (configuration)key and (configuration)value entries.
+   *
+   * @param topic the topic to be updated containing the full configuration
+   * @param fullTopicName fulltopic name
+   * @param dryRun dryrun options, if <code>true</code> no changes are applied to the cluster,
+   *     <code>false</code> otherwise.
+   * @return cluster changed configuration as map with (configuration)key and (configuration)value
+   *     entries
+   * @throws IOException thrown in case of any cluster execution error.
+   */
   public Map<String, String> updateTopicConfig(Topic topic, String fullTopicName, boolean dryRun)
       throws IOException {
     try {
@@ -167,7 +179,7 @@ public class TopologyBuilderAdminClient {
     List<AlterConfigOp> deleteConfigOps =
         resolveDeleteEntries(fullTopicName, actualTopicConfig, newEntryKeys, entryToOldValueMap);
 
-    if (!config.shouldOverwriteTopicsInSync() && !actualTopicConfig.entries().isEmpty()) {
+    if (!actualTopicConfig.entries().isEmpty()) {
       LOGGER.debug(
           "Existing topics with exact same configuration will not be overwritten/set again");
 
@@ -245,14 +257,6 @@ public class TopologyBuilderAdminClient {
   private Map<String, String> parseChangesBasedOnConfigs(
       List<AlterConfigOp> alterConfigOps, Map<String, String> entryToOldValueMap) {
     return alterConfigOps.stream()
-        .filter(
-            // (option to overwrite on and is changed value or the config is new) OR option to
-            // overwrite is off
-            c ->
-                (!config.shouldOverwriteTopicsInSync()
-                            && entryToOldValueMap.containsKey(c.configEntry().name())
-                        || entryToOldValueMap.isEmpty())
-                    || config.shouldOverwriteTopicsInSync())
         .collect(
             Collectors.toMap(
                 entry -> entry.configEntry().name(),

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology.api.adminclient;
 
+import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
@@ -7,9 +8,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
@@ -28,6 +31,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigResource.Type;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.logging.log4j.LogManager;
@@ -38,9 +42,11 @@ public class TopologyBuilderAdminClient {
   private static final Logger LOGGER = LogManager.getLogger(TopologyBuilderAdminClient.class);
 
   private final AdminClient adminClient;
+  private final Configuration config;
 
-  public TopologyBuilderAdminClient(AdminClient adminClient) {
+  public TopologyBuilderAdminClient(AdminClient adminClient, Configuration config) {
     this.adminClient = adminClient;
+    this.config = config;
   }
 
   public Set<String> listTopics(ListTopicsOptions options) throws IOException {
@@ -73,9 +79,10 @@ public class TopologyBuilderAdminClient {
     return listTopics(options);
   }
 
-  public void updateTopicConfig(Topic topic, String fullTopicName) throws IOException {
+  public Map<String, String> updateTopicConfig(Topic topic, String fullTopicName, boolean dryRun)
+      throws IOException {
     try {
-      updateTopicConfigPostAK23(topic, fullTopicName);
+      return updateTopicConfigPostAK23(topic, fullTopicName, dryRun);
     } catch (InterruptedException | ExecutionException ex) {
       LOGGER.error(ex);
       throw new IOException(ex);
@@ -141,45 +148,143 @@ public class TopologyBuilderAdminClient {
     }
   }
 
-  private void updateTopicConfigPostAK23(Topic topic, String fullTopicName)
+  private Map<String, String> updateTopicConfigPostAK23(
+      Topic topic, String fullTopicName, boolean dryRun)
       throws ExecutionException, InterruptedException {
 
-    Config currentConfigs = getActualTopicConfig(fullTopicName);
+    Config actualTopicConfig = getActualTopicConfig(fullTopicName);
+    List<AlterConfigOp> toBeSetConfigs =
+        topic.getRawConfig().entrySet().stream()
+            .map(
+                entry ->
+                    new AlterConfigOp(
+                        new ConfigEntry(entry.getKey(), entry.getValue()), OpType.SET))
+            .collect(Collectors.toList());
+
+    Set<String> newEntryKeys = topic.getRawConfig().keySet();
+    Map<String, String> entryToOldValueMap = new HashMap<>();
+
+    List<AlterConfigOp> deleteConfigOps =
+        resolveDeleteEntries(fullTopicName, actualTopicConfig, newEntryKeys, entryToOldValueMap);
+
+    if (!config.shouldOverwriteTopicsInSync() && !actualTopicConfig.entries().isEmpty()) {
+      LOGGER.debug(
+          "Existing topics with exact same configuration will not be overwritten/set again");
+
+      List<AlterConfigOp> syncConfigOps = new ArrayList<>(toBeSetConfigs);
+      // removing all same values again
+      toBeSetConfigs.forEach(
+          entry -> {
+            String configEntryName = entry.configEntry().name();
+            ConfigEntry configEntry = actualTopicConfig.get(configEntryName);
+            if (configEntry != null) {
+              String currentValue = configEntry.value();
+              String newValue = entry.configEntry().value();
+              if (newEntryKeys.contains(configEntryName) && currentValue.equals(newValue)) {
+                LOGGER.debug(
+                    "Topic {} and config key {} has the same value, removing config pair.",
+                    fullTopicName,
+                    configEntryName);
+                syncConfigOps.remove(entry);
+
+              } else {
+                entryToOldValueMap.put(configEntryName, currentValue);
+                LOGGER.debug(
+                    "Topic {} and config key {} updating value: {} -> {}",
+                    fullTopicName,
+                    configEntryName,
+                    currentValue,
+                    newValue);
+              }
+            }
+          });
+
+      if (syncConfigOps.isEmpty() && deleteConfigOps.isEmpty()) {
+        LOGGER.debug("Topic {} will not be updated, because it has no changes", fullTopicName);
+
+        return Collections.emptyMap();
+      }
+    }
+
+    // merge lists
+    toBeSetConfigs.addAll(deleteConfigOps);
 
     Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
-    ArrayList<AlterConfigOp> listOfValues = new ArrayList<>();
+    configs.put(new ConfigResource(Type.TOPIC, fullTopicName), toBeSetConfigs);
 
-    topic
-        .getRawConfig()
-        .forEach(
-            (configKey, configValue) -> {
-              listOfValues.add(
-                  new AlterConfigOp(new ConfigEntry(configKey, configValue), OpType.SET));
-            });
-    Set<String> newEntryKeys = topic.getRawConfig().keySet();
-
-    currentConfigs
-        .entries()
-        .forEach(
-            entry -> {
-              if (!entry.isDefault() && !newEntryKeys.contains(entry.name())) {
-                listOfValues.add(new AlterConfigOp(entry, OpType.DELETE));
-              }
-            });
-
-    configs.put(new ConfigResource(Type.TOPIC, fullTopicName), listOfValues);
-
-    adminClient.incrementalAlterConfigs(configs).all().get();
+    if (!dryRun) {
+      adminClient.incrementalAlterConfigs(configs).all().get();
+    }
+    return parseChangesBasedOnConfigs(toBeSetConfigs, entryToOldValueMap);
   }
 
-  private Config getActualTopicConfig(String topic)
-      throws ExecutionException, InterruptedException {
+  private List<AlterConfigOp> resolveDeleteEntries(
+      String fullTopicName,
+      Config currentConfigs,
+      Set<String> newEntryKeys,
+      Map<String, String> entryToOldValueMap) {
+    return currentConfigs.entries().stream()
+        // filter default values and static broker configs as they don't need to be defined in the
+        // julie
+        // config
+        .filter(
+            (entry ->
+                !entry.isDefault()
+                    && !entry.source().equals((ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG))
+                    && !newEntryKeys.contains(entry.name())))
+        .map(
+            entry -> {
+              LOGGER.debug(
+                  "Topic {} and config key {} deleting value", fullTopicName, entry.name());
+              entryToOldValueMap.put(entry.name(), entry.value());
+              return new AlterConfigOp(entry, OpType.DELETE);
+            })
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, String> parseChangesBasedOnConfigs(
+      List<AlterConfigOp> alterConfigOps, Map<String, String> entryToOldValueMap) {
+    return alterConfigOps.stream()
+        .filter(
+            // (option to overwrite on and is changed value or the config is new) OR option to
+            // overwrite is off
+            c ->
+                (!config.shouldOverwriteTopicsInSync()
+                            && entryToOldValueMap.containsKey(c.configEntry().name())
+                        || entryToOldValueMap.isEmpty())
+                    || config.shouldOverwriteTopicsInSync())
+        .collect(
+            Collectors.toMap(
+                entry -> entry.configEntry().name(),
+                config -> {
+                  String previousValue = entryToOldValueMap.get(config.configEntry().name());
+                  if (config.opType().equals(OpType.SET)) {
+                    return previousValue != null
+                        ? "[Update] " + previousValue + " -> " + config.configEntry().value()
+                        : "[Set] " + config.configEntry().value();
+                  } else if (config.opType().equals(OpType.DELETE)) {
+                    return "[Unset] " + previousValue + " ->  ";
+                  }
+                  // fallback case for other OPs
+                  LOGGER.warn("Unsupported Operation used {}", config.opType());
+                  return "[Unsupported Op] - " + config.opType();
+                }));
+  }
+
+  private Config getActualTopicConfig(String topic) throws InterruptedException {
     ConfigResource resource = new ConfigResource(Type.TOPIC, topic);
     Collection<ConfigResource> resources = Collections.singletonList(resource);
 
-    Map<ConfigResource, Config> configs = adminClient.describeConfigs(resources).all().get();
+    try {
+      Map<ConfigResource, Config> configs = adminClient.describeConfigs(resources).all().get();
 
-    return configs.get(resource);
+      return configs.get(resource);
+
+    } catch (ExecutionException | UnknownTopicOrPartitionException e) {
+      LOGGER.debug("Topic {} not found on the cluster - might be a new topic - continuing", topic);
+
+      return new Config(Collections.emptyList());
+    }
   }
 
   public void createTopic(Topic topic, String fullTopicName) throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClientBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClientBuilder.java
@@ -25,7 +25,8 @@ public class TopologyBuilderAdminClientBuilder {
         String.format(
             "Connecting AdminClient to %s",
             props.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG)));
-    TopologyBuilderAdminClient client = new TopologyBuilderAdminClient(AdminClient.create(props));
+    TopologyBuilderAdminClient client =
+        new TopologyBuilderAdminClient(AdminClient.create(props), config);
     if (!config.isDryRun()) {
       client.healthCheck();
     }

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -51,11 +51,7 @@ public class FileBackend implements Backend {
   public void createOrOpen(Mode mode) {
     try {
       if (this.writer != null) writer.close();
-      if (mode.equals(Mode.TRUNCATE)) {
-        this.writer = new FileWriter(STATE_FILE_NAME, false);
-      } else {
-        this.writer = new FileWriter(STATE_FILE_NAME, true);
-      }
+      this.writer = new FileWriter(STATE_FILE_NAME, !Mode.TRUNCATE.equals(mode));
     } catch (IOException e) {
       LOGGER.error(e);
     }

--- a/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
@@ -67,11 +67,11 @@ public class TopicImpl implements Topic, Cloneable {
     this(name, Optional.of(dataType), new HashMap<>(), new Configuration());
   }
 
-  public TopicImpl(String name, String dataType, HashMap<String, String> config) {
+  public TopicImpl(String name, String dataType, Map<String, String> config) {
     this(name, Optional.of(dataType), config, new Configuration());
   }
 
-  public TopicImpl(String name, HashMap<String, String> config) {
+  public TopicImpl(String name, Map<String, String> config) {
     this(name, Optional.empty(), config, new Configuration());
   }
 

--- a/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
@@ -169,7 +169,7 @@ public class TopicImpl implements Topic, Cloneable {
 
   @JsonIgnore
   @Override
-  public HashMap<String, String> getRawConfig() {
+  public Map<String, String> getRawConfig() {
     HashMap<String, String> raw = new HashMap<>(config);
     raw.remove(TopicManager.REPLICATION_FACTOR);
     raw.remove(TopicManager.NUM_PARTITIONS);

--- a/src/main/java/com/purbon/kafka/topology/model/Topic.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topic.java
@@ -23,6 +23,12 @@ public interface Topic {
 
   Map<String, String> getConfig();
 
+  /**
+   * Gets the "raw" config with all configuration keys except <i>replication.factor</i> and
+   * <i>num.partitions</i>.
+   *
+   * @return the raw config.
+   */
   HashMap<String, String> getRawConfig();
 
   Optional<String> getDataType();

--- a/src/main/java/com/purbon/kafka/topology/model/Topic.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topic.java
@@ -5,7 +5,6 @@ import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
 import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.Producer;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,7 +28,7 @@ public interface Topic {
    *
    * @return the raw config.
    */
-  HashMap<String, String> getRawConfig();
+  Map<String, String> getRawConfig();
 
   Optional<String> getDataType();
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -31,7 +31,6 @@ topology {
       separator = "."
     }
     managed.prefixes = []
-    sync.overwrite = true
   }
   project {
     prefix {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -31,6 +31,7 @@ topology {
       separator = "."
     }
     managed.prefixes = []
+    sync.overwrite = true
   }
   project {
     prefix {

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.purbon.kafka.topology.actions.Action;
 import com.purbon.kafka.topology.api.adminclient.AclBuilder;
 import com.purbon.kafka.topology.model.*;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
@@ -417,9 +418,8 @@ public class AccessControlManagerTest {
     accessControlManager.apply(builder.buildTopology(), plan);
 
     plan.run(true);
-    String expectedAction = plan.getActions().get(0).toString();
 
-    verify(mockPrintStream, times(1)).println(expectedAction);
+    verify(mockPrintStream, times(1)).println(any(Action.class));
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-import com.purbon.kafka.topology.actions.Action;
 import com.purbon.kafka.topology.api.adminclient.AclBuilder;
 import com.purbon.kafka.topology.model.*;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
@@ -418,8 +417,9 @@ public class AccessControlManagerTest {
     accessControlManager.apply(builder.buildTopology(), plan);
 
     plan.run(true);
+    String expectedAction = plan.getActions().get(0).toString();
 
-    verify(mockPrintStream, times(1)).println(any(Action.class));
+    verify(mockPrintStream, times(1)).println(expectedAction);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
@@ -4,7 +4,6 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.purbon.kafka.topology.actions.access.ClearBindings;
 import com.purbon.kafka.topology.actions.access.CreateBindings;
@@ -56,8 +55,6 @@ public class ExecutionPlanTest {
     TestUtils.deleteStateFile();
     backendController = new BackendController();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
-
-    when(configuration.shouldOverwriteTopicsInSync()).thenReturn(true);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.purbon.kafka.topology.actions.access.ClearBindings;
 import com.purbon.kafka.topology.actions.access.CreateBindings;
@@ -46,6 +47,8 @@ public class ExecutionPlanTest {
 
   @Mock TopologyBuilderAdminClient adminClient;
 
+  @Mock Configuration configuration;
+
   @Mock SchemaRegistryManager schemaRegistryManager;
 
   @Before
@@ -53,6 +56,8 @@ public class ExecutionPlanTest {
     TestUtils.deleteStateFile();
     backendController = new BackendController();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
+
+    when(configuration.shouldOverwriteTopicsInSync()).thenReturn(true);
   }
 
   @Test
@@ -104,6 +109,7 @@ public class ExecutionPlanTest {
     backendController = new BackendController();
     backendController.load();
     assertEquals(1, backendController.size());
+    backendController.flushAndClose();
   }
 
   @Test
@@ -111,15 +117,24 @@ public class ExecutionPlanTest {
     Topology topology = buildTopologyForTest();
     Topic topicFoo = topology.getProjects().get(0).getTopics().get(0);
     Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
-    Set<String> listOfTopics = new HashSet<>();
 
     SyncTopicAction addTopicAction1 =
         new SyncTopicAction(
-            adminClient, schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+            adminClient,
+            schemaRegistryManager,
+            configuration,
+            topicFoo,
+            topicFoo.toString(),
+            false);
 
     SyncTopicAction addTopicAction2 =
         new SyncTopicAction(
-            adminClient, schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+            adminClient,
+            schemaRegistryManager,
+            configuration,
+            topicBar,
+            topicBar.toString(),
+            false);
 
     plan.add(addTopicAction1);
     plan.add(addTopicAction2);
@@ -136,15 +151,24 @@ public class ExecutionPlanTest {
     Topology topology = buildTopologyForTest();
     Topic topicFoo = topology.getProjects().get(0).getTopics().get(0);
     Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
-    Set<String> listOfTopics = new HashSet<>();
 
     SyncTopicAction addTopicAction1 =
         new SyncTopicAction(
-            adminClient, schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+            adminClient,
+            schemaRegistryManager,
+            configuration,
+            topicFoo,
+            topicFoo.toString(),
+            false);
 
     SyncTopicAction addTopicAction2 =
         new SyncTopicAction(
-            adminClient, schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+            adminClient,
+            schemaRegistryManager,
+            configuration,
+            topicBar,
+            topicBar.toString(),
+            false);
 
     plan.add(addTopicAction1);
     plan.add(addTopicAction2);

--- a/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
@@ -103,6 +103,7 @@ public class PrincipalManagerTest {
 
     assertThat(plan.getActions()).hasSize(1);
     assertThat(plan.getActions()).containsAnyOf(new CreateAccounts(provider, accounts));
+    backendController.flushAndClose();
   }
 
   @Test
@@ -130,6 +131,7 @@ public class PrincipalManagerTest {
 
     assertThat(plan.getActions()).hasSize(1);
     assertThat(plan.getActions()).containsAnyOf(new CreateAccounts(provider, accounts));
+    backendController.flushAndClose();
   }
 
   @Test
@@ -167,7 +169,6 @@ public class PrincipalManagerTest {
     plan = ExecutionPlan.init(backendController, mockPrintStream);
     principalManager.applyCreate(topology, plan);
     principalManager.applyDelete(topology, plan);
-    ;
 
     Collection<ServiceAccount> accounts =
         Arrays.asList(new ServiceAccount(124, "producer", "Managed by KTB"));
@@ -195,6 +196,7 @@ public class PrincipalManagerTest {
     principalManager.applyDelete(topology, plan);
 
     verify(mockPlan, times(0)).add(any(Action.class));
+    backendController.flushAndClose();
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
@@ -7,6 +7,7 @@ import static com.purbon.kafka.topology.TopicManager.NUM_PARTITIONS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
+import com.purbon.kafka.topology.actions.Action;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
@@ -336,7 +337,7 @@ public class TopicManagerTest {
     topicManager.apply(topology, plan);
     plan.run(true);
 
-    verify(outputStream, times(2)).println(any(String.class));
+    verify(outputStream, times(2)).println(any(Action.class));
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
@@ -7,7 +7,6 @@ import static com.purbon.kafka.topology.TopicManager.NUM_PARTITIONS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-import com.purbon.kafka.topology.actions.Action;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
@@ -22,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -120,7 +120,7 @@ public class TopicManagerTest {
 
     verify(adminClient, times(0)).createTopic(topicA, topicA.toString());
     verify(adminClient, times(0)).createTopic(topicB, topicB.toString());
-    verify(adminClient, times(1)).updateTopicConfig(topicB, topicB.toString());
+    verify(adminClient, times(1)).updateTopicConfig(topicB, topicB.toString(), false);
     verify(adminClient, times(1)).getPartitionCount(topicB.toString());
     verify(adminClient, times(1)).updatePartitionCount(topicB, topicB.toString());
   }
@@ -200,8 +200,7 @@ public class TopicManagerTest {
     String topicI1 = "foo.my-internal.topic";
     String topicI2 = "_my-internal.topic";
 
-    Set<String> appTopics =
-        Arrays.asList(topicC, topicI1, topicI2).stream().collect(Collectors.toSet());
+    Set<String> appTopics = new HashSet<>(Arrays.asList(topicC, topicI1, topicI2));
     when(adminClient.listApplicationTopics()).thenReturn(appTopics);
 
     topicManager.apply(topology, plan);
@@ -238,7 +237,7 @@ public class TopicManagerTest {
 
     String topicC = "team.project.topicC";
 
-    Set<String> appTopics = Arrays.asList(topicC).stream().collect(Collectors.toSet());
+    Set<String> appTopics = Stream.of(topicC).collect(Collectors.toSet());
     when(adminClient.listApplicationTopics()).thenReturn(appTopics);
 
     topicManager.apply(topology, plan);
@@ -337,7 +336,7 @@ public class TopicManagerTest {
     topicManager.apply(topology, plan);
     plan.run(true);
 
-    verify(outputStream, times(2)).println(any(Action.class));
+    verify(outputStream, times(2)).println(any(String.class));
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderAdminClientTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderAdminClientTest.java
@@ -262,7 +262,7 @@ public class TopologyBuilderAdminClientTest {
   }
 
   @Test
-  public void resolveConfigForAllTopicsForOverwrite() throws IOException {
+  public void resolveConfigForAllTopics() throws IOException {
     // new config
     String topicNameA = "topicA";
     Map<String, String> configTopicA = new HashMap<>();

--- a/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
@@ -81,5 +81,6 @@ public class FileBackendTest {
     assertThat(topics).hasSize(2);
     assertThat(topics).contains(fooTopic.toString());
     assertThat(topics).contains(barTopic.toString());
+    backend.close();
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -74,7 +74,8 @@ public class AccessControlManagerIT {
   @Before
   public void before() throws IOException {
     kafkaAdminClient = ContainerTestUtils.getSaslAdminClient(container);
-    TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
+    TopologyBuilderAdminClient adminClient =
+        new TopologyBuilderAdminClient(kafkaAdminClient, config);
     adminClient.clearAcls();
     TestUtils.deleteStateFile();
 

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -48,6 +48,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -58,6 +59,7 @@ public class TopicManagerIT {
   private AdminClient kafkaAdminClient;
 
   private ExecutionPlan plan;
+  @Mock private Configuration configuration;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -77,7 +79,8 @@ public class TopicManagerIT {
     Files.deleteIfExists(Paths.get(".cluster-state"));
 
     kafkaAdminClient = ContainerTestUtils.getSaslAdminClient(container);
-    TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
+    TopologyBuilderAdminClient adminClient =
+        new TopologyBuilderAdminClient(kafkaAdminClient, configuration);
 
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final SchemaRegistryManager schemaRegistryManager =

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
@@ -87,7 +87,7 @@ public final class ContainerTestUtils {
     final Configuration builderConfig =
         Configuration.build(cliParams, TestUtils.getResourceFilename(configResource));
     final TopologyBuilderAdminClient topologyAdminClient =
-        new TopologyBuilderAdminClient(kafkaAdminClient);
+        new TopologyBuilderAdminClient(kafkaAdminClient, builderConfig);
     final AccessControlProvider accessControlProvider = new SimpleAclsProvider(topologyAdminClient);
     final BindingsBuilderProvider bindingsBuilderProvider = new AclsBindingsBuilder(builderConfig);
     try {


### PR DESCRIPTION
Implements #220 and fixes #217.

I touched some places where I did replace logger output and added documentation where it was missing (and helpful).
Additionally, on windows :-( the tests were not running as already pointed out at #217 which I changed as well due to testability on my local.

The change is backwards compatible and the default value is making sure that the new feature #220 will not be enabled. The only noticeable change is the output of the dryrun which is more detailed than before.

I did not update the changelog.md as I have the feeling it is outdated and not used currently or only updated when something get's released.

I was really having a hardtime to keep on with the formatting as there was no guideline or .editorconfig file for the rules. I hope I did not change the style to much.