### PR TITLE
Add support and checks for non ascii characters in schema content and topics

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/schemas/SchemaRegistryManager.java
+++ b/src/main/java/com/purbon/kafka/topology/schemas/SchemaRegistryManager.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.schemas;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +50,7 @@ public class SchemaRegistryManager {
     LOGGER.debug(
         String.format("Registering subject %s with source %s", subjectName, schemaFilePath));
     try {
-      final String schema = new String(Files.readAllBytes(schemaFilePath));
+      final String schema = new String(Files.readAllBytes(schemaFilePath), StandardCharsets.UTF_8);
       return save(subjectName, format, schema);
     } catch (Exception e) {
       throw new SchemaRegistryManagerException(

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
@@ -26,16 +26,8 @@ public class TopologySerdes {
     this(new Configuration(), FileType.YAML, new PlanMap());
   }
 
-  public TopologySerdes(Configuration config) {
-    this(config, config.getTopologyFileType(), new PlanMap());
-  }
-
   public TopologySerdes(Configuration config, PlanMap plans) {
     this(config, config.getTopologyFileType(), plans);
-  }
-
-  public TopologySerdes(Configuration config, FileType type) {
-    mapper = ObjectMapperFactory.build(type, config, new PlanMap());
   }
 
   public TopologySerdes(Configuration config, FileType type, PlanMap plans) {

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -11,13 +11,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import com.purbon.kafka.topology.model.*;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;
-import com.purbon.kafka.topology.model.Project;
-import com.purbon.kafka.topology.model.Topic;
-import com.purbon.kafka.topology.model.Topology;
-import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.KStream;
@@ -348,7 +345,7 @@ public class TopologySerdesTest {
     props.put(TOPIC_PREFIX_SEPARATOR_CONFIG, "_");
     Configuration config = new Configuration(cliOps, props);
 
-    TopologySerdes parser = new TopologySerdes(config);
+    TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
         parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
@@ -372,7 +369,7 @@ public class TopologySerdesTest {
     props.put(TOPIC_PREFIX_FORMAT_CONFIG, "{{source}}.{{context}}.{{project}}.{{topic}}");
     Configuration config = new Configuration(cliOps, props);
 
-    TopologySerdes parser = new TopologySerdes(config);
+    TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
         parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
@@ -386,9 +383,14 @@ public class TopologySerdesTest {
     assertEquals("source.contextOrg.foo.bar", p.getTopics().get(1).toString());
   }
 
+  @Test(expected = TopologyParsingException.class)
+  public void testTopicNameWithUTFCharacters() {
+    parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics-utf.yaml"));
+  }
+
   @Test
   public void testJsonDescriptorFileSerdes() {
-    TopologySerdes parser = new TopologySerdes(new Configuration(), FileType.JSON);
+    TopologySerdes parser = new TopologySerdes(new Configuration(), FileType.JSON, new PlanMap());
     Topology topology = parser.deserialise(TestUtils.getResourceFile("/descriptor.json"));
 
     assertEquals(1, topology.getProjects().size());

--- a/src/test/resources/descriptor-only-topics-utf.yaml
+++ b/src/test/resources/descriptor-only-topics-utf.yaml
@@ -16,7 +16,7 @@ projects:
   - name: "bar"
     topics:
       - dataType: "avro"
-        name: "bar"
+        name: "bär"
         config:
           replication.factor: "1"
           num.partitions: "1"

--- a/src/test/resources/descriptor-schemas-utf.yaml
+++ b/src/test/resources/descriptor-schemas-utf.yaml
@@ -1,0 +1,23 @@
+---
+context: "schemas"
+type: "utf"
+projects:
+  - name: "foo"
+    consumers:
+      - principal: "User:App0"
+        group: "foo"
+      - principal: "User:App1"
+    producers:
+      - principal: "User:App0"
+      - principal: "User:App2"
+        transactionId: "1234"
+      - principal: "User:App2"
+        idempotence: "true"
+    topics:
+      - name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+        dataType: "avro"
+        schemas:
+          value.schema.file: "schemas/bar-utf-value.avsc"

--- a/src/test/resources/schemas/bar-utf-value.avsc
+++ b/src/test/resources/schemas/bar-utf-value.avsc
@@ -1,0 +1,9 @@
+{
+   "type" : "record",
+   "namespace" : "julieOps",
+   "name" : "Employee",
+   "fields" : [
+      { "name" : "Näme" , "type" : "string" },
+      { "name" : "Äge" , "type" : "int" }
+   ]
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduces two main things:

* Support for reading schema files using UTF-8 content, so it can have characters such as umlaut.
* Verifications when topic names are deserialized so in case it will not match the requirement in kafka (ASCII alphanumerics, '.', '_' and '-') it will raise an exception earlier.

Other components will be handled in detail when they come in. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No backwards-incompatible change is introduced, as only verifications and an extension of supported character encoding is add.
 

closes #228 