### PR TITLE
Backport from master to 2.x (sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # An operational manager for Apache Kafka (Automation, GitOps, SelfService)
 
-*NOTE*: This project was formally known as Kafka Topology Builder, old versions of this project can still be found under that name.
+*NOTE*: This project was formerly known as Kafka Topology Builder, old versions of this project can still be found under that name.
 
 <a href="https://codeclimate.com/github/purbon/kafka-topology-builder/maintainability"><img src="https://api.codeclimate.com/v1/badges/ef4bcda7d1b5fd0a4f1e/maintainability" /></a> ![CI tests](https://github.com/kafka-ops/kafka-topology-builder/workflows/CI%20tests/badge.svg?branch=master) [![Gitter](https://badges.gitter.im/kafka-topology-builder/community.svg)](https://gitter.im/kafka-topology-builder/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Documentation Status](https://readthedocs.org/projects/julieops/badge/?version=latest)](https://julieops.readthedocs.io/?badge=latest)
 

--- a/pom.xml
+++ b/pom.xml
@@ -416,14 +416,14 @@
     <spotbugs-maven-plugin.version>3.1.12.2</spotbugs-maven-plugin.version>
     <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
-    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <rpm-maven-plugin.version>2.2.0</rpm-maven-plugin.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     <!-- dependencies -->
     <jackson.version>2.12.1</jackson.version>
-    <kafka.version>2.5.0</kafka.version>
+    <kafka.version>2.7.0</kafka.version>
     <log4j.version>2.13.3</log4j.version>
     <httpclient.version>4.5.11</httpclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
@@ -432,8 +432,8 @@
     <junit.version>4.13.1</junit.version>
     <testcontainers.version>1.15.2</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
-    <confluent.version>5.5.0</confluent.version>
-    <confluent-ce.version>5.5.1-ce</confluent-ce.version>
+    <confluent.version>6.1.0</confluent.version>
+    <confluent-ce.version>6.1.0-ce</confluent-ce.version>
     <avro.version>1.9.2</avro.version>
     <jersey.version>2.22.2</jersey.version>
     <hamcrest.version>2.2</hamcrest.version>

--- a/src/main/java/com/purbon/kafka/topology/schemas/SchemaRegistryManager.java
+++ b/src/main/java/com/purbon/kafka/topology/schemas/SchemaRegistryManager.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.schemas;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +50,7 @@ public class SchemaRegistryManager {
     LOGGER.debug(
         String.format("Registering subject %s with source %s", subjectName, schemaFilePath));
     try {
-      final String schema = new String(Files.readAllBytes(schemaFilePath));
+      final String schema = new String(Files.readAllBytes(schemaFilePath), StandardCharsets.UTF_8);
       return save(subjectName, format, schema);
     } catch (Exception e) {
       throw new SchemaRegistryManagerException(

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
@@ -26,16 +26,8 @@ public class TopologySerdes {
     this(new Configuration(), FileType.YAML, new PlanMap());
   }
 
-  public TopologySerdes(Configuration config) {
-    this(config, config.getTopologyFileType(), new PlanMap());
-  }
-
   public TopologySerdes(Configuration config, PlanMap plans) {
     this(config, config.getTopologyFileType(), plans);
-  }
-
-  public TopologySerdes(Configuration config, FileType type) {
-    mapper = ObjectMapperFactory.build(type, config, new PlanMap());
   }
 
   public TopologySerdes(Configuration config, FileType type, PlanMap plans) {

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -11,13 +11,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import com.purbon.kafka.topology.model.*;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;
-import com.purbon.kafka.topology.model.Project;
-import com.purbon.kafka.topology.model.Topic;
-import com.purbon.kafka.topology.model.Topology;
-import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.KStream;
@@ -348,7 +345,7 @@ public class TopologySerdesTest {
     props.put(TOPIC_PREFIX_SEPARATOR_CONFIG, "_");
     Configuration config = new Configuration(cliOps, props);
 
-    TopologySerdes parser = new TopologySerdes(config);
+    TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
         parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
@@ -372,7 +369,7 @@ public class TopologySerdesTest {
     props.put(TOPIC_PREFIX_FORMAT_CONFIG, "{{source}}.{{context}}.{{project}}.{{topic}}");
     Configuration config = new Configuration(cliOps, props);
 
-    TopologySerdes parser = new TopologySerdes(config);
+    TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
         parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
@@ -386,9 +383,14 @@ public class TopologySerdesTest {
     assertEquals("source.contextOrg.foo.bar", p.getTopics().get(1).toString());
   }
 
+  @Test(expected = TopologyParsingException.class)
+  public void testTopicNameWithUTFCharacters() {
+    parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics-utf.yaml"));
+  }
+
   @Test
   public void testJsonDescriptorFileSerdes() {
-    TopologySerdes parser = new TopologySerdes(new Configuration(), FileType.JSON);
+    TopologySerdes parser = new TopologySerdes(new Configuration(), FileType.JSON, new PlanMap());
     Topology topology = parser.deserialise(TestUtils.getResourceFile("/descriptor.json"));
 
     assertEquals(1, topology.getProjects().size());

--- a/src/test/java/com/purbon/kafka/topology/schemas/SchemaRegistryManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/schemas/SchemaRegistryManagerTest.java
@@ -178,12 +178,13 @@ public class SchemaRegistryManagerTest {
         Paths.get(
             getClass()
                 .getClassLoader()
-                .getResource("schemas/test-backward-compatible.json")
+                .getResource("schemas/test-forward-compatible.json")
                 .toURI());
     final String updatedSampleSchema = new String(Files.readAllBytes(updatedSchemaFilePath));
 
     final ParsedSchema parsedUpdatedSampleSchema =
         client.parseSchema(schemaTypeJson, updatedSampleSchema, Collections.emptyList()).get();
+
     assertThat(client.testCompatibility(subjectName, parsedUpdatedSampleSchema)).isTrue();
 
     assertThat(manager.save(subjectName, schemaTypeJson, updatedSampleSchema)).isEqualTo(2);
@@ -205,7 +206,7 @@ public class SchemaRegistryManagerTest {
         Paths.get(
             getClass()
                 .getClassLoader()
-                .getResource("schemas/test-forward-compatible.json")
+                .getResource("schemas/test-backward-compatible.json")
                 .toURI());
     final String updatedSampleSchema = new String(Files.readAllBytes(updatedSchemaFilePath));
 

--- a/src/test/resources/descriptor-only-topics-utf.yaml
+++ b/src/test/resources/descriptor-only-topics-utf.yaml
@@ -16,7 +16,7 @@ projects:
   - name: "bar"
     topics:
       - dataType: "avro"
-        name: "bar"
+        name: "bär"
         config:
           replication.factor: "1"
           num.partitions: "1"

--- a/src/test/resources/descriptor-schemas-utf.yaml
+++ b/src/test/resources/descriptor-schemas-utf.yaml
@@ -1,0 +1,23 @@
+---
+context: "schemas"
+type: "utf"
+projects:
+  - name: "foo"
+    consumers:
+      - principal: "User:App0"
+        group: "foo"
+      - principal: "User:App1"
+    producers:
+      - principal: "User:App0"
+      - principal: "User:App2"
+        transactionId: "1234"
+      - principal: "User:App2"
+        idempotence: "true"
+    topics:
+      - name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+        dataType: "avro"
+        schemas:
+          value.schema.file: "schemas/bar-utf-value.avsc"

--- a/src/test/resources/schemas/bar-utf-value.avsc
+++ b/src/test/resources/schemas/bar-utf-value.avsc
@@ -1,0 +1,9 @@
+{
+   "type" : "record",
+   "namespace" : "julieOps",
+   "name" : "Employee",
+   "fields" : [
+      { "name" : "Näme" , "type" : "string" },
+      { "name" : "Äge" , "type" : "int" }
+   ]
+}


### PR DESCRIPTION
backport recent features to the 2.x release train

* add support and checks for non ascii characters in schema content (#230)
* Upgrade dependencies to Kafka 2.7 and Confluent 6.1, plus some other