### PR TITLE
Backend management refactoring, S3 and GCP Backend integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ example/topology-builder-with-schema-cloud.properties
 release/
 private.key
 rpm-gen-key
+.s3/

--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -47,7 +47,7 @@ It is necessary for the topology builder to keep some state, if it does not retr
 for example for situations when the tool needs to decide what ACLs to remove.
 As well this property is important when the tool does not manage all topics in the cluster, so it is important to know it context.
 
-The default implementation is a File, however is possible ot use other systems.
+The default implementation is a File, however is possible ot use other systems such as S3, GCP Storage or Redis.
 To configure it you can use:
 
 Configure the state management system.
@@ -56,6 +56,8 @@ Configure the state management system.
 **values**:
  - File: "com.purbon.kafka.topology.backend.FileBackend"
  - Redis: "com.purbon.kafka.topology.backend.RedisBackend"
+ - S3: "com.purbon.kafka.topology.backend.S3Backend"
+ - GCP: "com.purbon.kafka.topology.backend.GCPBackend"
 
 If you are using redis, you need to extend two other properties to setup the server location:
 ::

--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <assertj.version>3.15.0</assertj.version>
     <jinjava.version>2.5.4</jinjava.version>
+    <aws.java.sdk.version>2.16.31</aws.java.sdk.version>
   </properties>
 
   <dependencies>
@@ -554,6 +555,10 @@
       <version>${commons.version}</version>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>${hamcrest.version}</version>
@@ -595,5 +600,22 @@
       <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.findify</groupId>
+      <artifactId>s3mock_2.13</artifactId>
+      <version>0.2.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws.java.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,7 @@
     <assertj.version>3.15.0</assertj.version>
     <jinjava.version>2.5.4</jinjava.version>
     <aws.java.sdk.version>2.16.31</aws.java.sdk.version>
+    <gcp.java.sdk.version>19.2.1</gcp.java.sdk.version>
   </properties>
 
   <dependencies>
@@ -559,6 +560,10 @@
       <artifactId>s3</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>${hamcrest.version}</version>
@@ -613,6 +618,13 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
         <version>${aws.java.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${gcp.java.sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -13,15 +13,14 @@ import org.apache.logging.log4j.Logger;
 
 public class BackendController {
 
+  public static final String STATE_FILE_NAME = ".cluster-state";
+
   public enum Mode {
     TRUNCATE,
     APPEND
   }
 
   private static final Logger LOGGER = LogManager.getLogger(BackendController.class);
-
-  private static final String STORE_TYPE = "acls";
-
   private final Backend backend;
   private BackendState state;
 
@@ -62,9 +61,8 @@ public class BackendController {
   }
 
   public void flushAndClose() throws IOException {
-    LOGGER.debug(String.format("Flushing the current state of %s", STORE_TYPE));
+    LOGGER.debug(String.format("Flush data from the backend at %s", backend.getClass()));
     backend.createOrOpen(Mode.TRUNCATE);
-    backend.saveType(STORE_TYPE);
     backend.save(state);
     backend.close();
   }

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -1,11 +1,11 @@
 package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.backend.Backend;
+import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.FileBackend;
 import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -23,9 +23,7 @@ public class BackendController {
   private static final String STORE_TYPE = "acls";
 
   private final Backend backend;
-  private Set<String> topics;
-  private Set<TopologyAclBinding> bindings;
-  private Set<ServiceAccount> serviceAccounts;
+  private BackendState state;
 
   public BackendController() {
     this(new FileBackend());
@@ -33,66 +31,56 @@ public class BackendController {
 
   public BackendController(Backend backend) {
     this.backend = backend;
-    this.bindings = new HashSet<>();
-    this.serviceAccounts = new HashSet<>();
-    this.topics = new HashSet<>();
+    this.state = new BackendState();
   }
 
   public void addBindings(List<TopologyAclBinding> bindings) {
     LOGGER.debug(String.format("Adding bindings %s to the backend", bindings));
-    this.bindings.addAll(bindings);
+    state.addBindings(bindings);
   }
 
   public void addTopics(Set<String> topics) {
     LOGGER.debug(String.format("Adding topics %s to the backend", topics));
-    this.topics.addAll(topics);
+    state.addTopics(topics);
   }
 
   public void addServiceAccounts(Set<ServiceAccount> serviceAccounts) {
     LOGGER.debug(String.format("Adding Service Accounts %s to the backend", serviceAccounts));
-    this.serviceAccounts.addAll(serviceAccounts);
+    state.addAccounts(serviceAccounts);
   }
 
   public Set<ServiceAccount> getServiceAccounts() {
-    return new HashSet<>(serviceAccounts);
+    return state.getAccounts();
   }
 
   public Set<TopologyAclBinding> getBindings() {
-    return bindings;
+    return state.getBindings();
   }
 
   public Set<String> getTopics() {
-    return topics;
+    return state.getTopics();
   }
 
-  public void flushAndClose() {
-    LOGGER.debug(String.format("Flushing the current state of %s, %s", STORE_TYPE, bindings));
+  public void flushAndClose() throws IOException {
+    LOGGER.debug(String.format("Flushing the current state of %s", STORE_TYPE));
     backend.createOrOpen(Mode.TRUNCATE);
     backend.saveType(STORE_TYPE);
-    backend.saveBindings(bindings);
-    backend.saveType("ServiceAccounts");
-    backend.saveAccounts(serviceAccounts);
-    backend.saveType("Topics");
-    backend.saveTopics(topics);
+    backend.save(state);
     backend.close();
   }
 
   public void load() throws IOException {
     LOGGER.debug(String.format("Loading data from the backend at %s", backend.getClass()));
     backend.createOrOpen();
-    bindings.addAll(backend.loadBindings());
-    serviceAccounts.addAll(backend.loadServiceAccounts());
-    topics.addAll(backend.loadTopics());
+    state = backend.load();
   }
 
   public void reset() {
     LOGGER.debug("Reset the bindings cache");
-    bindings.clear();
-    serviceAccounts.clear();
-    topics.clear();
+    state.clear();
   }
 
   public int size() {
-    return bindings.size() + serviceAccounts.size() + topics.size();
+    return state.size();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -317,4 +317,12 @@ public class Configuration {
   public String getS3Region() {
     return config.getString(JULIE_S3_REGION);
   }
+
+  public String getGCPProjectId() {
+    return config.getString(JULIE_GCP_PROJECT_ID);
+  }
+
+  public String getGCPBucket() {
+    return config.getString(JULIE_GCP_BUCKET);
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -309,4 +309,12 @@ public class Configuration {
   public boolean fetchTopicStateFromTheCluster() {
     return fetchStateFromTheCluster() || config.getBoolean(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER);
   }
+
+  public String getS3Bucket() {
+    return config.getString(JULIE_S3_BUCKET);
+  }
+
+  public String getS3Region() {
+    return config.getString(JULIE_S3_REGION);
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -77,4 +77,7 @@ public class Constants {
       "topology.builder.internal.principal";
 
   public static final String JULIE_INTERNAL_PRINCIPAL = "julie.internal.principal";
+
+  public static final String JULIE_S3_REGION = "julie.s3.region";
+  public static final String JULIE_S3_BUCKET = "julie.s3.bucket";
 }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -24,6 +24,12 @@ public class Constants {
   public static final String REDIS_STATE_PROCESSOR_CLASS =
       "com.purbon.kafka.topology.backend.RedisBackend";
 
+  public static final String S3_STATE_PROCESSOR_CLASS =
+          "com.purbon.kafka.topology.backend.S3Backend";
+
+  public static final String GCP_STATE_PROCESSOR_CLASS =
+          "com.purbon.kafka.topology.backend.GCPBackend";
+
   public static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
   public static final String REDIS_PORT_CONFIG = "topology.builder.redis.port";
 
@@ -80,4 +86,6 @@ public class Constants {
 
   public static final String JULIE_S3_REGION = "julie.s3.region";
   public static final String JULIE_S3_BUCKET = "julie.s3.bucket";
+  public static final String JULIE_GCP_PROJECT_ID = "julie.gcp.project.id";
+  public static final String JULIE_GCP_BUCKET = "julie.gcp.bucket";
 }

--- a/src/main/java/com/purbon/kafka/topology/JulieOps.java
+++ b/src/main/java/com/purbon/kafka/topology/JulieOps.java
@@ -5,9 +5,7 @@ import static com.purbon.kafka.topology.Constants.*;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClientBuilder;
 import com.purbon.kafka.topology.api.mds.MDSApiClientBuilder;
-import com.purbon.kafka.topology.backend.Backend;
-import com.purbon.kafka.topology.backend.FileBackend;
-import com.purbon.kafka.topology.backend.RedisBackend;
+import com.purbon.kafka.topology.backend.*;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.schemas.SchemaRegistryManager;
@@ -219,17 +217,21 @@ public class JulieOps implements AutoCloseable {
 
   private static BackendController buildBackendController(Configuration config) throws IOException {
 
-    String stateProcessorClass = config.getStateProcessorImplementationClassName();
+    String backendClass = config.getStateProcessorImplementationClassName();
     Backend backend = null;
     try {
-      if (stateProcessorClass.equalsIgnoreCase(STATE_PROCESSOR_DEFAULT_CLASS)) {
+      if (backendClass.equalsIgnoreCase(STATE_PROCESSOR_DEFAULT_CLASS)) {
         backend = new FileBackend();
-      } else if (stateProcessorClass.equalsIgnoreCase(REDIS_STATE_PROCESSOR_CLASS)) {
+      } else if (backendClass.equalsIgnoreCase(REDIS_STATE_PROCESSOR_CLASS)) {
         String host = config.getProperty(REDIS_HOST_CONFIG);
         int port = Integer.parseInt(config.getProperty(REDIS_PORT_CONFIG));
         backend = new RedisBackend(host, port);
+      } else if (backendClass.equalsIgnoreCase(S3_STATE_PROCESSOR_CLASS)) {
+        backend = new S3Backend();
+      } else if (backendClass.equalsIgnoreCase(GCP_STATE_PROCESSOR_CLASS)) {
+        backend = new GCPBackend();
       } else {
-        throw new IOException(stateProcessorClass + " Unknown state processor provided.");
+        throw new IOException(backendClass + " Unknown state processor provided.");
       }
     } catch (Exception ex) {
       throw new IOException(ex);

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
@@ -67,7 +67,7 @@ public class MDSApiClient extends JulieHttpClient {
 
   public void bindRequest(TopologyAclBinding binding) throws IOException {
 
-    String url = binding.getPrincipal() + "/roles/" + binding.getRole();
+    String url = binding.getPrincipal() + "/roles/" + binding.getOperation();
     if (!binding.getResourceType().equals(ResourceType.CLUSTER)) {
       url = url + "/bindings";
     }

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -1,10 +1,7 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController;
-import com.purbon.kafka.topology.model.cluster.ServiceAccount;
-import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.util.Set;
 
 public interface Backend {
 
@@ -12,19 +9,11 @@ public interface Backend {
 
   void createOrOpen(BackendController.Mode mode);
 
-  Set<ServiceAccount> loadServiceAccounts() throws IOException;
-
-  Set<TopologyAclBinding> loadBindings() throws IOException;
-
-  Set<String> loadTopics() throws IOException;
-
   void saveType(String type);
 
-  void saveBindings(Set<TopologyAclBinding> bindings);
-
-  void saveAccounts(Set<ServiceAccount> accounts);
-
-  void saveTopics(Set<String> topics);
-
   void close();
+
+  void save(BackendState state) throws IOException;
+
+  BackendState load() throws IOException;
 }

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -10,9 +10,13 @@ public interface Backend {
     // empty if not implemented
   }
 
-  void createOrOpen();
+  default void createOrOpen() {
+    // empty if not implemented
+  }
 
-  void createOrOpen(BackendController.Mode mode);
+  default void createOrOpen(BackendController.Mode mode) {
+    // empty if not implemented
+  }
 
   void close();
 

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -1,9 +1,14 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController;
+import com.purbon.kafka.topology.Configuration;
 import java.io.IOException;
 
 public interface Backend {
+
+  default void configure(Configuration config) {
+    // empty if not implemented
+  }
 
   void createOrOpen();
 

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -9,8 +9,6 @@ public interface Backend {
 
   void createOrOpen(BackendController.Mode mode);
 
-  void saveType(String type);
-
   void close();
 
   void save(BackendState state) throws IOException;

--- a/src/main/java/com/purbon/kafka/topology/backend/BackendState.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/BackendState.java
@@ -1,0 +1,62 @@
+package com.purbon.kafka.topology.backend;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import com.purbon.kafka.topology.utils.JSON;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BackendState {
+
+  private final Set<TopologyAclBinding> bindings;
+  private final Set<ServiceAccount> accounts;
+  private final Set<String> topics;
+
+  public BackendState() {
+    this.accounts = new HashSet<>();
+    this.bindings = new HashSet<>();
+    this.topics = new HashSet<>();
+  }
+
+  public void addAccounts(Collection<ServiceAccount> accounts) {
+    this.accounts.addAll(accounts);
+  }
+
+  public void addBindings(Collection<TopologyAclBinding> bindings) {
+    this.bindings.addAll(bindings);
+  }
+
+  public void addTopics(Collection<String> topics) {
+    this.topics.addAll(topics);
+  }
+
+  public Set<TopologyAclBinding> getBindings() {
+    return bindings;
+  }
+
+  public Set<ServiceAccount> getAccounts() {
+    return accounts;
+  }
+
+  public Set<String> getTopics() {
+    return topics;
+  }
+
+  @JsonIgnore
+  public String asJson() throws JsonProcessingException {
+    return JSON.asString(this);
+  }
+
+  public void clear() {
+    bindings.clear();
+    accounts.clear();
+    topics.clear();
+  }
+
+  public int size() {
+    return bindings.size() + accounts.size() + topics.size();
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -1,5 +1,7 @@
 package com.purbon.kafka.topology.backend;
 
+import static com.purbon.kafka.topology.BackendController.STATE_FILE_NAME;
+
 import com.purbon.kafka.topology.BackendController.Mode;
 import com.purbon.kafka.topology.utils.JSON;
 import java.io.BufferedReader;
@@ -15,8 +17,6 @@ import org.apache.logging.log4j.Logger;
 public class FileBackend extends AbstractBackend {
 
   private static final Logger LOGGER = LogManager.getLogger(FileBackend.class);
-  public static final String STATE_FILE_NAME = ".cluster-state";
-  static final String ACLS_TAG = "acls";
 
   // Use FileWriter instead of RandomAccessFile due to
   // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4715154
@@ -57,8 +57,6 @@ public class FileBackend extends AbstractBackend {
       return (BackendState) JSON.toObject(backendStateAsJsonString, BackendState.class);
     }
   }
-
-  public void saveType(String type) {}
 
   private void writeLine(String line) throws IOException {
     try {

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -1,23 +1,14 @@
 package com.purbon.kafka.topology.backend;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.purbon.kafka.topology.BackendController.Mode;
-import com.purbon.kafka.topology.model.cluster.ServiceAccount;
-import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import com.purbon.kafka.topology.utils.JSON;
-import java.io.*;
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -25,8 +16,6 @@ public class FileBackend extends AbstractBackend {
 
   private static final Logger LOGGER = LogManager.getLogger(FileBackend.class);
   public static final String STATE_FILE_NAME = ".cluster-state";
-  static final String SERVICE_ACCOUNTS_TAG = "ServiceAccounts";
-  static final String TOPICS_TAG = "Topics";
   static final String ACLS_TAG = "acls";
 
   // Use FileWriter instead of RandomAccessFile due to
@@ -52,131 +41,32 @@ public class FileBackend extends AbstractBackend {
     }
   }
 
-  public Set<TopologyAclBinding> loadBindings() throws IOException {
-    if (writer == null) {
-      throw new IOException("state file does not exist");
-    }
-    File file = new File(STATE_FILE_NAME);
-    return load(file.toURI());
-  }
-
-  public Set<TopologyAclBinding> load(URI uri) throws IOException {
-    Path filePath = Paths.get(uri);
-    Set<TopologyAclBinding> bindings = new LinkedHashSet<>();
-    try (BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()))) {
-      String type = in.readLine();
-      String line = null;
-      while ((line = in.readLine()) != null) {
-        TopologyAclBinding binding = null;
-        if (line.equalsIgnoreCase("ServiceAccounts")) {
-          // process service accounts, should break from here.
-          break;
-        }
-        if (type.equalsIgnoreCase(ACLS_TAG)) {
-          binding = buildAclBinding(line);
-        } else {
-          throw new IOException("Binding type ( " + type + " )not supported.");
-        }
-        bindings.add(binding);
-      }
-    }
-    return bindings;
-  }
-
-  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
-    return loadItemsFromFile(
-            SERVICE_ACCOUNTS_TAG,
-            line -> {
-              try {
-                return JSON.toObject(line, ServiceAccount.class);
-              } catch (JsonProcessingException e) {
-                LOGGER.error(e);
-                return null;
-              }
-            })
-        .stream()
-        .filter(Objects::nonNull)
-        .map(o -> (ServiceAccount) o)
-        .collect(Collectors.toSet());
-  }
-
-  private boolean foundAControlTag(String line) {
-    return line.equalsIgnoreCase(SERVICE_ACCOUNTS_TAG)
-        || line.equalsIgnoreCase(TOPICS_TAG)
-        || line.equalsIgnoreCase(ACLS_TAG);
+  @Override
+  public void save(BackendState state) throws IOException {
+    writeLine(state.asJson());
   }
 
   @Override
-  public Set<String> loadTopics() throws IOException {
-    return loadItemsFromFile(TOPICS_TAG, String::trim).stream()
-        .map(String::valueOf)
-        .collect(Collectors.toSet());
-  }
-
-  private Set<Object> loadItemsFromFile(String tag, Function<String, Object> buildFunction)
-      throws IOException {
-    if (writer == null) {
-      throw new IOException("state file does not exist");
-    }
-    Set<Object> elements = new HashSet<>();
-    try (BufferedReader in = openLocalStateFile()) {
-      String line = moveFileToTag(tag, in);
-      if (line != null && line.equalsIgnoreCase(tag)) {
-        while ((line = in.readLine()) != null && !foundAControlTag(line)) {
-          elements.add(buildFunction.apply(line.trim()));
-        }
-      }
-    }
-    return elements;
-  }
-
-  private BufferedReader openLocalStateFile() throws IOException {
+  public BackendState load() throws IOException {
     Path filePath = Paths.get(STATE_FILE_NAME);
-    return new BufferedReader(new FileReader(filePath.toFile()));
-  }
-
-  private String moveFileToTag(String tag, BufferedReader in) throws IOException {
-    String line = null;
-    while ((line = in.readLine()) != null) {
-      if (line.equalsIgnoreCase(tag)) {
-        break; // process elements, should start from here.
-      }
+    if (Files.size(filePath) == 0) { // if we are loading when there is no file or is empty.
+      return new BackendState();
     }
-    return line;
+    try (BufferedReader reader = new BufferedReader(new FileReader(filePath.toFile()))) {
+      String backendStateAsJsonString = reader.readLine();
+      return (BackendState) JSON.toObject(backendStateAsJsonString, BackendState.class);
+    }
   }
 
-  public void saveType(String type) {
-    writeLine(type);
-  }
+  public void saveType(String type) {}
 
-  @Override
-  public void saveBindings(Set<TopologyAclBinding> bindings) {
-    bindings.stream().sorted().forEach(b -> writeLine(b.toString()));
-  }
-
-  @Override
-  public void saveAccounts(Set<ServiceAccount> accounts) {
-    accounts.forEach(
-        a -> {
-          try {
-            writeLine(JSON.asString(a));
-          } catch (JsonProcessingException e) {
-            LOGGER.error(e);
-          }
-        });
-  }
-
-  @Override
-  public void saveTopics(Set<String> topics) {
-    topics.forEach(this::writeLine);
-  }
-
-  private void writeLine(String line) {
+  private void writeLine(String line) throws IOException {
     try {
       writer.write(line);
       writer.write("\n");
     } catch (IOException e) {
       LOGGER.error(e);
+      throw e;
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/backend/GCPBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/GCPBackend.java
@@ -1,0 +1,63 @@
+package com.purbon.kafka.topology.backend;
+
+import static com.purbon.kafka.topology.BackendController.STATE_FILE_NAME;
+
+import com.google.cloud.storage.*;
+import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.utils.JSON;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class GCPBackend extends AbstractBackend {
+
+  private static final Logger LOGGER = LogManager.getLogger(GCPBackend.class);
+
+  private Storage storage;
+  private Configuration config;
+
+  @Override
+  public void configure(Configuration config) {
+    configure(config, null);
+  }
+
+  public void configure(Configuration config, URI endpoint) {
+    this.config = config;
+    this.storage =
+        StorageOptions.newBuilder().setProjectId(config.getGCPProjectId()).build().getService();
+  }
+
+  @Override
+  public void save(BackendState state) throws IOException {
+    BlobId blobId = BlobId.of(config.getGCPBucket(), STATE_FILE_NAME);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    try {
+      storage.create(
+          blobInfo,
+          state.asJson().getBytes(StandardCharsets.UTF_8),
+          Storage.BlobTargetOption.detectContentType());
+    } catch (Exception ex) {
+      LOGGER.error(ex);
+      throw new IOException(ex);
+    }
+  }
+
+  @Override
+  public BackendState load() throws IOException {
+    try {
+      Blob blob = storage.get(BlobId.of(config.getGCPBucket(), STATE_FILE_NAME));
+      String contentJson = new String(blob.getContent(), StandardCharsets.UTF_8);
+      return (BackendState) JSON.toObject(contentJson, BackendState.class);
+    } catch (Exception ex) {
+      LOGGER.error(ex);
+      throw new IOException(ex);
+    }
+  }
+
+  @Override
+  public void close() {
+    // empty
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
@@ -1,7 +1,6 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController.Mode;
-import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.HashSet;
@@ -42,45 +41,21 @@ public class RedisBackend extends AbstractBackend {
   }
 
   @Override
-  public Set<TopologyAclBinding> loadBindings() throws IOException {
-    connectIfNeed();
-
-    Set<TopologyAclBinding> bindings = new HashSet<>();
-    String type = jedis.get(JULIE_OPS_TYPE);
-
-    long count = jedis.scard(JULIE_OPS_BINDINGS);
-    for (long i = 0; i < count; i++) {
-      String elem = jedis.spop(JULIE_OPS_BINDINGS);
-      TopologyAclBinding binding = buildAclBinding(elem);
-      bindings.add(binding);
-    }
-
-    return bindings;
-  }
-
-  private void connectIfNeed() {
-    if (!jedis.isConnected()) {
-      createOrOpen();
-    }
-  }
-
-  @Override
-  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
-    return new HashSet<>();
-  }
-
-  @Override
-  public Set<String> loadTopics() throws IOException {
-    return new HashSet<>();
-  }
-
-  @Override
   public void saveType(String type) {
     jedis.set(JULIE_OPS_TYPE, type);
   }
 
   @Override
-  public void saveBindings(Set<TopologyAclBinding> bindings) {
+  public void close() {
+    jedis.close();
+  }
+
+  @Override
+  public void save(BackendState state) throws IOException {
+    saveBindings(state.getBindings());
+  }
+
+  private void saveBindings(Set<TopologyAclBinding> bindings) {
 
     String[] members =
         bindings.stream().map(TopologyAclBinding::toString).toArray(size -> new String[size]);
@@ -89,13 +64,27 @@ public class RedisBackend extends AbstractBackend {
   }
 
   @Override
-  public void saveAccounts(Set<ServiceAccount> accounts) {}
+  public BackendState load() throws IOException {
+    BackendState state = new BackendState();
+    state.addBindings(loadBindings());
+    return state;
+  }
 
-  @Override
-  public void saveTopics(Set<String> topics) {}
+  private Set<TopologyAclBinding> loadBindings() throws IOException {
+    connectIfNeed();
+    Set<TopologyAclBinding> bindings = new HashSet<>();
+    long count = jedis.scard(JULIE_OPS_BINDINGS);
+    for (long i = 0; i < count; i++) {
+      String elem = jedis.spop(JULIE_OPS_BINDINGS);
+      TopologyAclBinding binding = buildAclBinding(elem);
+      bindings.add(binding);
+    }
+    return bindings;
+  }
 
-  @Override
-  public void close() {
-    jedis.close();
+  private void connectIfNeed() {
+    if (!jedis.isConnected()) {
+      createOrOpen();
+    }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
@@ -41,11 +41,6 @@ public class RedisBackend extends AbstractBackend {
   }
 
   @Override
-  public void saveType(String type) {
-    jedis.set(JULIE_OPS_TYPE, type);
-  }
-
-  @Override
   public void close() {
     jedis.close();
   }

--- a/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
@@ -24,13 +24,15 @@ public class S3Backend extends AbstractBackend {
   private S3Client s3;
   private Configuration config;
 
+  @Override
   public void configure(Configuration config) {
     configure(config, null);
   }
+
+  // Visible and used for tests
   public void configure(Configuration config, URI endpoint) {
     this.config = config;
-    S3ClientBuilder builder = S3Client.builder()
-            .region(Region.of(config.getS3Region()));
+    S3ClientBuilder builder = S3Client.builder().region(Region.of(config.getS3Region()));
     if (endpoint != null) {
       builder = builder.endpointOverride(endpoint);
     }

--- a/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
@@ -26,15 +27,20 @@ public class S3Backend extends AbstractBackend {
 
   @Override
   public void configure(Configuration config) {
-    configure(config, null);
+    configure(config, null, false);
   }
 
   // Visible and used for tests
-  public void configure(Configuration config, URI endpoint) {
+  public void configure(Configuration config, URI endpoint, boolean anonymous) {
     this.config = config;
-    S3ClientBuilder builder = S3Client.builder().region(Region.of(config.getS3Region()));
+    S3ClientBuilder builder = S3Client
+            .builder()
+            .region(Region.of(config.getS3Region()));
     if (endpoint != null) {
       builder = builder.endpointOverride(endpoint);
+    }
+    if (anonymous) {
+      builder = builder.credentialsProvider(AnonymousCredentialsProvider.create());
     }
     this.s3 = builder.build();
   }

--- a/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
@@ -1,0 +1,94 @@
+package com.purbon.kafka.topology.backend;
+
+import com.purbon.kafka.topology.BackendController;
+import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.utils.JSON;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.*;
+
+public class S3Backend extends AbstractBackend {
+
+  private static final Logger LOGGER = LogManager.getLogger(S3Backend.class);
+  public static final String STATE_FILE_NAME = ".cluster-state";
+
+  private S3Client s3;
+  private Configuration config;
+
+  public void configure(Configuration config) {
+    configure(config, null);
+  }
+  public void configure(Configuration config, URI endpoint) {
+    this.config = config;
+    S3ClientBuilder builder = S3Client.builder()
+            .region(Region.of(config.getS3Region()));
+    if (endpoint != null) {
+      builder = builder.endpointOverride(endpoint);
+    }
+    this.s3 = builder.build();
+  }
+
+  @Override
+  public void createOrOpen() {}
+
+  @Override
+  public void createOrOpen(BackendController.Mode mode) {}
+
+  @Override
+  public void saveType(String type) {}
+
+  @Override
+  public void save(BackendState state) throws IOException {
+    flushRemoteStateContent(state.asJson(), STATE_FILE_NAME);
+  }
+
+  @Override
+  public BackendState load() throws IOException {
+    try {
+      String content = getRemoteStateContent(STATE_FILE_NAME);
+      return (BackendState) JSON.toObject(content, BackendState.class);
+    } catch (IOException ex) {
+      LOGGER.debug(ex);
+      return new BackendState();
+    }
+  }
+
+  @Override
+  public void close() {
+    s3.close();
+  }
+
+  private String getRemoteStateContent(String key) throws IOException {
+    GetObjectRequest request =
+        GetObjectRequest.builder().key(key).bucket(config.getS3Bucket()).build();
+
+    try {
+      ResponseBytes<GetObjectResponse> objectBytes = s3.getObjectAsBytes(request);
+      return objectBytes.asString(StandardCharsets.UTF_8);
+    } catch (S3Exception ex) {
+      LOGGER.error(ex);
+      throw new IOException(ex);
+    }
+  }
+
+  private String flushRemoteStateContent(String content, String key) throws IOException {
+    PutObjectRequest request =
+        PutObjectRequest.builder().bucket(config.getS3Bucket()).key(key).build();
+    try {
+      PutObjectResponse response =
+          s3.putObject(request, RequestBody.fromString(content, StandardCharsets.UTF_8));
+      return response.eTag();
+    } catch (S3Exception ex) {
+      LOGGER.error(ex);
+      throw new IOException(ex);
+    }
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
@@ -33,9 +33,7 @@ public class S3Backend extends AbstractBackend {
   // Visible and used for tests
   public void configure(Configuration config, URI endpoint, boolean anonymous) {
     this.config = config;
-    S3ClientBuilder builder = S3Client
-            .builder()
-            .region(Region.of(config.getS3Region()));
+    S3ClientBuilder builder = S3Client.builder().region(Region.of(config.getS3Region()));
     if (endpoint != null) {
       builder = builder.endpointOverride(endpoint);
     }
@@ -44,12 +42,6 @@ public class S3Backend extends AbstractBackend {
     }
     this.s3 = builder.build();
   }
-
-  @Override
-  public void createOrOpen() {}
-
-  @Override
-  public void createOrOpen(BackendController.Mode mode) {}
 
   @Override
   public void save(BackendState state) throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/S3Backend.java
@@ -1,5 +1,7 @@
 package com.purbon.kafka.topology.backend;
 
+import static com.purbon.kafka.topology.BackendController.STATE_FILE_NAME;
+
 import com.purbon.kafka.topology.BackendController;
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.utils.JSON;
@@ -18,7 +20,6 @@ import software.amazon.awssdk.services.s3.model.*;
 public class S3Backend extends AbstractBackend {
 
   private static final Logger LOGGER = LogManager.getLogger(S3Backend.class);
-  public static final String STATE_FILE_NAME = ".cluster-state";
 
   private S3Client s3;
   private Configuration config;
@@ -41,9 +42,6 @@ public class S3Backend extends AbstractBackend {
 
   @Override
   public void createOrOpen(BackendController.Mode mode) {}
-
-  @Override
-  public void saveType(String type) {}
 
   @Override
   public void save(BackendState state) throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
@@ -185,10 +185,6 @@ public class TopologyAclBinding implements Comparable<TopologyAclBinding> {
         getPattern());
   }
 
-  public String getRole() {
-    return operation;
-  }
-
   private RequestScope scope;
 
   public void setScope(RequestScope scope) {

--- a/src/test/java/com/purbon/kafka/topology/BackendControllerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/BackendControllerTest.java
@@ -1,10 +1,12 @@
 package com.purbon.kafka.topology;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.FileBackend;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
@@ -37,9 +39,9 @@ public class BackendControllerTest {
         TopologyAclBinding.build(
             ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
 
-    when(fileStateProcessor.loadBindings()).thenReturn(Collections.singleton(binding));
+    when(fileStateProcessor.load()).thenReturn(new BackendState());
     backend.load();
-    verify(fileStateProcessor, times(1)).loadBindings();
+    verify(fileStateProcessor, times(1)).load();
   }
 
   @Test
@@ -56,7 +58,7 @@ public class BackendControllerTest {
   }
 
   @Test
-  public void testStoreBindingsAndServiceAccounts() {
+  public void testStoreBindingsAndServiceAccounts() throws IOException {
 
     BackendController backend = new BackendController(fileStateProcessor);
 
@@ -71,12 +73,11 @@ public class BackendControllerTest {
 
     backend.flushAndClose();
 
-    verify(fileStateProcessor, times(1)).saveBindings(Collections.singleton(binding));
-    verify(fileStateProcessor, times(1)).saveAccounts(Collections.singleton(serviceAccount));
+    verify(fileStateProcessor, times(1)).save(any(BackendState.class));
   }
 
   @Test
-  public void testStoreBindingsAndTopics() {
+  public void testStoreBindingsAndTopics() throws IOException {
     BackendController backend = new BackendController(fileStateProcessor);
 
     Topic topic = new TopicImpl("foo");
@@ -94,8 +95,6 @@ public class BackendControllerTest {
     backend.addTopics(Collections.singleton(topic.getName()));
 
     backend.flushAndClose();
-
-    verify(fileStateProcessor, times(1)).saveBindings(Collections.singleton(binding));
-    verify(fileStateProcessor, times(1)).saveTopics(Collections.singleton(topic.getName()));
+    verify(fileStateProcessor, times(1)).save(any(BackendState.class));
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
+++ b/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import com.purbon.kafka.topology.BackendController.Mode;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.exceptions.TopologyParsingException;
 import com.purbon.kafka.topology.utils.TestUtils;
@@ -36,11 +37,13 @@ public class JulieOpsTest {
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
+  @Mock RedisBackend stateProcessor;
+
   private Map<String, String> cliOps;
   private Properties props;
 
   @Before
-  public void before() {
+  public void before() throws IOException {
     cliOps = new HashMap<>();
     cliOps.put(BROKERS_OPTION, "");
     cliOps.put(ADMIN_CLIENT_CONFIG_OPTION, "/fooBar");
@@ -49,6 +52,8 @@ public class JulieOpsTest {
     props.put(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG, "http://foo:8082");
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "");
     props.put(AdminClientConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
+
+    when(stateProcessor.load()).thenReturn(new BackendState());
   }
 
   @Test
@@ -148,8 +153,6 @@ public class JulieOpsTest {
     verify(topicManager, times(1)).apply(anyObject(), anyObject());
     verify(accessControlManager, times(1)).apply(anyObject(), anyObject());
   }
-
-  @Mock RedisBackend stateProcessor;
 
   @Test
   public void builderRunTestAsFromCLIWithARedisBackend() throws Exception {

--- a/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
@@ -1,7 +1,6 @@
 package com.purbon.kafka.topology.backend;
 
-import static com.purbon.kafka.topology.backend.FileBackend.ACLS_TAG;
-import static com.purbon.kafka.topology.backend.FileBackend.STATE_FILE_NAME;
+import static com.purbon.kafka.topology.BackendController.STATE_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.purbon.kafka.topology.BackendController.Mode;
@@ -64,7 +63,6 @@ public class FileBackendTest {
     state.addTopics(Arrays.asList(fooTopic.toString(), barTopic.toString()));
 
     backend.createOrOpen(Mode.TRUNCATE);
-    backend.saveType(ACLS_TAG);
     backend.save(state);
     backend.close();
 

--- a/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
@@ -1,9 +1,7 @@
 package com.purbon.kafka.topology.backend;
 
 import static com.purbon.kafka.topology.backend.FileBackend.ACLS_TAG;
-import static com.purbon.kafka.topology.backend.FileBackend.SERVICE_ACCOUNTS_TAG;
 import static com.purbon.kafka.topology.backend.FileBackend.STATE_FILE_NAME;
-import static com.purbon.kafka.topology.backend.FileBackend.TOPICS_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.purbon.kafka.topology.BackendController.Mode;
@@ -15,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.kafka.common.resource.ResourceType;
 import org.junit.After;
@@ -62,19 +59,22 @@ public class FileBackendTest {
     Topic fooTopic = builder.getTopic("foo");
     Topic barTopic = builder.getTopic("bar");
 
+    BackendState state = new BackendState();
+    state.addBindings(Collections.singleton(binding));
+    state.addTopics(Arrays.asList(fooTopic.toString(), barTopic.toString()));
+
     backend.createOrOpen(Mode.TRUNCATE);
     backend.saveType(ACLS_TAG);
-    backend.saveBindings(Collections.singleton(binding));
-    backend.saveType(SERVICE_ACCOUNTS_TAG);
-    backend.saveType(TOPICS_TAG);
-    backend.saveTopics(new HashSet<>(Arrays.asList(fooTopic.toString(), barTopic.toString())));
+    backend.save(state);
     backend.close();
 
     backend = new FileBackend();
     backend.createOrOpen();
 
-    Set<TopologyAclBinding> bindings = backend.loadBindings();
-    Set<String> topics = backend.loadTopics();
+    BackendState recoveredState = backend.load();
+
+    Set<TopologyAclBinding> bindings = recoveredState.getBindings();
+    Set<String> topics = recoveredState.getTopics();
 
     assertThat(bindings).hasSize(1);
     assertThat(bindings).contains(binding);

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -26,7 +26,6 @@ public class RedisBackendIT {
     RedisBackend rsp = new RedisBackend(host, port);
     rsp.createOrOpen();
 
-    rsp.saveType("acls");
     TopologyAclBinding binding =
         TopologyAclBinding.build(
             ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -1,11 +1,10 @@
 package com.purbon.kafka.topology.integration.backend;
 
+import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collections;
 import org.apache.kafka.common.resource.ResourceType;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -31,11 +30,15 @@ public class RedisBackendIT {
     TopologyAclBinding binding =
         TopologyAclBinding.build(
             ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");
-    rsp.saveBindings(new HashSet<>(Arrays.asList(binding)));
 
-    Set<TopologyAclBinding> bindings = rsp.loadBindings();
+    BackendState state = new BackendState();
+    state.addBindings(Collections.singleton(binding));
+    rsp.save(state);
 
-    Assert.assertEquals(1, bindings.size());
-    Assert.assertEquals(binding.getPrincipal(), bindings.iterator().next().getPrincipal());
+    BackendState recoveredState = rsp.load();
+
+    Assert.assertEquals(1, recoveredState.getBindings().size());
+    Assert.assertEquals(
+        binding.getPrincipal(), recoveredState.getBindings().iterator().next().getPrincipal());
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -1,0 +1,93 @@
+package com.purbon.kafka.topology.integration.backend;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.backend.BackendState;
+import com.purbon.kafka.topology.backend.S3Backend;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import io.findify.s3mock.S3Mock;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.waiters.S3Waiter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.purbon.kafka.topology.CommandLineInterface.*;
+import static com.purbon.kafka.topology.Constants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class S3BackendIT {
+
+    private S3Mock api;
+    private Map<String, String> cliOps;
+
+    private static final String TEST_BUCKET = "testbucket";
+
+    @Before
+    public void before() {
+        cliOps = new HashMap<>();
+        cliOps.put(BROKERS_OPTION, "");
+
+        api = S3Mock.create(8001, "/tmp/s3");
+        api.start();
+
+
+        AmazonS3Client client = new AmazonS3Client(new AnonymousAWSCredentials());
+        // use local API mock, not the AWS one
+        client.setEndpoint("http://127.0.0.1:8001");
+        client.createBucket(TEST_BUCKET);
+        //client.putObject("testbucket", "file/name", "contents");
+
+
+    }
+
+    @After
+    public void after() {
+        api.shutdown();
+    }
+
+    @Test
+    public void testContentCreation() throws IOException {
+
+        S3Backend backend = new S3Backend();
+
+        Properties props = new Properties();
+        props.put(JULIE_S3_REGION, "us-west-2");
+        props.put(JULIE_S3_BUCKET, TEST_BUCKET);
+
+        Configuration config = new Configuration(cliOps, props);
+        backend.configure(config, URI.create("http://localhost:8001"));
+
+        TopologyAclBinding binding =
+                TopologyAclBinding.build(
+                        ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");
+
+        BackendState state = new BackendState();
+        state.addBindings(Collections.singleton(binding));
+        backend.save(state);
+        backend.close();
+
+        S3Backend newBackend = new S3Backend();
+        newBackend.configure(config, URI.create("http://localhost:8001"));
+
+        BackendState newState = newBackend.load();
+        assertThat(newState.size()).isEqualTo(1);
+        assertThat(newState.getBindings()).contains(binding);
+    }
+}
+

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -13,7 +13,6 @@ import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import io.findify.s3mock.S3Mock;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -1,93 +1,79 @@
 package com.purbon.kafka.topology.integration.backend;
 
+import static com.purbon.kafka.topology.CommandLineInterface.*;
+import static com.purbon.kafka.topology.Constants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.S3Backend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import io.findify.s3mock.S3Mock;
-import org.apache.kafka.common.resource.ResourceType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import software.amazon.awssdk.core.waiters.WaiterResponse;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.waiters.S3Waiter;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import static com.purbon.kafka.topology.CommandLineInterface.*;
-import static com.purbon.kafka.topology.Constants.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class S3BackendIT {
 
-    private S3Mock api;
-    private Map<String, String> cliOps;
+  private S3Mock api;
+  private Map<String, String> cliOps;
 
-    private static final String TEST_BUCKET = "testbucket";
+  private static final String TEST_BUCKET = "testbucket";
+  private static final String TEST_ENDPOINT = "http://127.0.0.1:8001";
 
-    @Before
-    public void before() {
-        cliOps = new HashMap<>();
-        cliOps.put(BROKERS_OPTION, "");
+  @Before
+  public void before() {
+    cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
 
-        api = S3Mock.create(8001, "/tmp/s3");
-        api.start();
+    api = S3Mock.create(8001, "/tmp/s3");
+    api.start();
 
+    AmazonS3Client client = new AmazonS3Client(new AnonymousAWSCredentials());
+    client.setEndpoint(TEST_ENDPOINT);
+    client.createBucket(TEST_BUCKET);
+  }
 
-        AmazonS3Client client = new AmazonS3Client(new AnonymousAWSCredentials());
-        // use local API mock, not the AWS one
-        client.setEndpoint("http://127.0.0.1:8001");
-        client.createBucket(TEST_BUCKET);
-        //client.putObject("testbucket", "file/name", "contents");
+  @After
+  public void after() {
+    api.shutdown();
+  }
 
+  @Test
+  public void testContentCreation() throws IOException {
 
-    }
+    S3Backend backend = new S3Backend();
 
-    @After
-    public void after() {
-        api.shutdown();
-    }
+    Properties props = new Properties();
+    props.put(JULIE_S3_REGION, "us-west-2");
+    props.put(JULIE_S3_BUCKET, TEST_BUCKET);
 
-    @Test
-    public void testContentCreation() throws IOException {
+    Configuration config = new Configuration(cliOps, props);
+    backend.configure(config, URI.create(TEST_ENDPOINT));
 
-        S3Backend backend = new S3Backend();
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");
 
-        Properties props = new Properties();
-        props.put(JULIE_S3_REGION, "us-west-2");
-        props.put(JULIE_S3_BUCKET, TEST_BUCKET);
+    BackendState state = new BackendState();
+    state.addBindings(Collections.singleton(binding));
+    backend.save(state);
+    backend.close();
 
-        Configuration config = new Configuration(cliOps, props);
-        backend.configure(config, URI.create("http://localhost:8001"));
+    S3Backend newBackend = new S3Backend();
+    newBackend.configure(config, URI.create(TEST_ENDPOINT));
 
-        TopologyAclBinding binding =
-                TopologyAclBinding.build(
-                        ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");
-
-        BackendState state = new BackendState();
-        state.addBindings(Collections.singleton(binding));
-        backend.save(state);
-        backend.close();
-
-        S3Backend newBackend = new S3Backend();
-        newBackend.configure(config, URI.create("http://localhost:8001"));
-
-        BackendState newState = newBackend.load();
-        assertThat(newState.size()).isEqualTo(1);
-        assertThat(newState.getBindings()).contains(binding);
-    }
+    BackendState newState = newBackend.load();
+    assertThat(newState.size()).isEqualTo(1);
+    assertThat(newState.getBindings()).contains(binding);
+  }
 }
-

--- a/src/test/java/com/purbon/kafka/topology/utils/TestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/utils/TestUtils.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology.utils;
 
-import com.purbon.kafka.topology.backend.FileBackend;
+import static com.purbon.kafka.topology.BackendController.STATE_FILE_NAME;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -14,7 +15,7 @@ public final class TestUtils {
 
   public static void deleteStateFile() {
     try {
-      Files.deleteIfExists(Paths.get(FileBackend.STATE_FILE_NAME));
+      Files.deleteIfExists(Paths.get(STATE_FILE_NAME));
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Done:

* move local file state to use a JSON format based on the backstage class. This will help add and manage new fields in the state when required (this change is not backwards compatible and will only go to 3.x version)
* Add S3 Backend integration
* Add GCP Backend integration

closes #193 #197 
