### PR TITLE
Configurable TopologyValidator plugin mechanism

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology.validation.topology;
 
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
@@ -14,9 +15,9 @@ public class TopicNameRegexValidation implements TopologyValidation {
 
   private String topicNamePattern;
 
-  public TopicNameRegexValidation() {
-    LOGGER.info("Wish you were here...");
-    topicNamePattern = ".*"; // this is just for demonstration purposes..
+  public TopicNameRegexValidation() throws ConfigurationException {
+    throw new ConfigurationException(
+        "TopicNameRegexValidation is configured without specifying a topic name pattern");
   }
 
   public TopicNameRegexValidation(String pattern) {

--- a/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
@@ -1,0 +1,45 @@
+package com.purbon.kafka.topology.validation.topology;
+
+import com.purbon.kafka.topology.exceptions.ValidationException;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.validation.TopologyValidation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TopicNameRegexValidation implements TopologyValidation {
+
+  private static final Logger LOGGER = LogManager.getLogger(TopicNameRegexValidation.class);
+
+  private String topicNamePattern;
+
+  public TopicNameRegexValidation() {
+    LOGGER.info("Wish you were here...");
+    topicNamePattern = ".*"; // this is just for demonstration purposes..
+  }
+
+  public TopicNameRegexValidation(String pattern) {
+    this.topicNamePattern = pattern;
+    LOGGER.info(String.format("Applying Topic Name Regex Validation [%s]", pattern));
+  }
+
+  @Override
+  public void valid(Topology topology) throws ValidationException {
+
+    for (Project project : topology.getProjects()) {
+      for (Topic topic : project.getTopics()) {
+        matches(topic.toString());
+      }
+    }
+  }
+
+  public void matches(String topicName) throws ValidationException {
+    if (!topicName.matches(topicNamePattern)) {
+      String msg =
+          String.format(
+              "topic name '%s' does not follow the regex: %s", topicName, topicNamePattern);
+      throw new ValidationException(msg);
+    }
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topology/TopicNameRegexValidation.java
@@ -1,13 +1,21 @@
 package com.purbon.kafka.topology.validation.topology;
 
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.validation.TopologyValidation;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
 
 public class TopicNameRegexValidation implements TopologyValidation {
 
@@ -16,8 +24,25 @@ public class TopicNameRegexValidation implements TopologyValidation {
   private String topicNamePattern;
 
   public TopicNameRegexValidation() throws ConfigurationException {
-    throw new ConfigurationException(
-        "TopicNameRegexValidation is configured without specifying a topic name pattern");
+	  Config config = ConfigFactory.load();
+	  try {
+		  this.topicNamePattern = config.getString("topology.validations.regexp");
+	  } catch (ConfigException e) {
+		  throw new ConfigurationException(
+			        "TopicNameRegexValidation requires you to define your regex in config 'topology.validations.regexp'");
+	  }
+
+	  if (StringUtils.isBlank(topicNamePattern)) {
+		  throw new ConfigurationException(
+	        "TopicNameRegexValidation is configured without specifying a topic name pattern. Use config 'topology.validations.regexp'");
+	  }
+	  
+	  try {
+          Pattern.compile(topicNamePattern);
+      } catch (PatternSyntaxException exception) {
+		  throw new ConfigurationException(
+			        String.format("TopicNameRegexValidation configured with unvalid regex '%s'", topicNamePattern));
+      }
   }
 
   public TopicNameRegexValidation(String pattern) {
@@ -39,7 +64,7 @@ public class TopicNameRegexValidation implements TopologyValidation {
     if (!topicName.matches(topicNamePattern)) {
       String msg =
           String.format(
-              "topic name '%s' does not follow the regex: %s", topicName, topicNamePattern);
+              "Topic name '%s' does not follow regex: %s", topicName, topicNamePattern);
       throw new ValidationException(msg);
     }
   }


### PR DESCRIPTION
By solving [this issue](https://github.com/kafka-ops/julie/issues/236), this PR also introduces some configurable flexibility in the validator 'framework'. It allows a potential String parameter to be inserted in the constructor by naming convention (# is used as a separator in this example). It can then be used in the corresponding _TopologyValidatorImpl_ at will.

It's backwards compatible. 

**Still work in progress. Feedback is welcome and community acceptance is required before proceeding.**

* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

