### PR TITLE
Use Set as internal datastructure for 'principals to be created' instead of List.

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/PrincipalManager.java
+++ b/src/main/java/com/purbon/kafka/topology/PrincipalManager.java
@@ -48,12 +48,12 @@ public class PrincipalManager {
     List<String> principals = parseListOfPrincipals(topology);
     Map<String, ServiceAccount> accounts = loadActualClusterStateIfAvailable(plan);
 
-    // build list of principals to be created.
-    List<ServiceAccount> principalsToBeCreated =
+    // build set of principals to be created.
+    Set<ServiceAccount> principalsToBeCreated =
         principals.stream()
             .filter(wishPrincipal -> !accounts.containsKey(wishPrincipal))
             .map(principal -> new ServiceAccount(-1, principal, "Managed by KTB"))
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
 
     if (!principalsToBeCreated.isEmpty()) {
       plan.add(new CreateAccounts(provider, principalsToBeCreated));

--- a/src/main/java/com/purbon/kafka/topology/actions/accounts/CreateAccounts.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/accounts/CreateAccounts.java
@@ -4,7 +4,6 @@ import com.purbon.kafka.topology.PrincipalProvider;
 import com.purbon.kafka.topology.actions.BaseAccountsAction;
 import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -14,7 +13,7 @@ public class CreateAccounts extends BaseAccountsAction {
 
   private static final Logger LOGGER = LogManager.getLogger(CreateAccounts.class);
 
-  public CreateAccounts(PrincipalProvider provider, Collection<ServiceAccount> accounts) {
+  public CreateAccounts(PrincipalProvider provider, Set<ServiceAccount> accounts) {
     super(provider, accounts);
   }
 

--- a/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import jersey.repackaged.com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,8 +89,8 @@ public class PrincipalManagerTest {
     Topology topology = new TopologyImpl();
     topology.setContext("context");
     Project project = new ProjectImpl("foo");
-    project.setConsumers(Collections.singletonList(new Consumer("consumer")));
-    project.setProducers(Collections.singletonList(new Producer("producer")));
+    project.setConsumers(Collections.singletonList(new Consumer("consumer-principal")));
+    project.setProducers(Collections.singletonList(new Producer("producer-principal")));
     topology.addProject(project);
 
     doNothing().when(provider).configure();
@@ -96,10 +98,10 @@ public class PrincipalManagerTest {
     principalManager.applyCreate(topology, plan);
     principalManager.applyDelete(topology, plan);
 
-    Collection<ServiceAccount> accounts =
-        Arrays.asList(
-            new ServiceAccount(-1, "consumer", "Managed by KTB"),
-            new ServiceAccount(-1, "producer", "Managed by KTB"));
+    Set<ServiceAccount> accounts =
+        Sets.newHashSet(
+            new ServiceAccount(-1, "consumer-principal", "Managed by KTB"),
+            new ServiceAccount(-1, "producer-principal", "Managed by KTB"));
 
     assertThat(plan.getActions()).hasSize(1);
     assertThat(plan.getActions()).containsAnyOf(new CreateAccounts(provider, accounts));
@@ -113,8 +115,8 @@ public class PrincipalManagerTest {
     topology.setContext("context");
     Project project = new ProjectImpl("foo");
     Topic topic = new TopicImpl("baa");
-    topic.setConsumers(Collections.singletonList(new Consumer("topicConsumer")));
-    topic.setProducers(Collections.singletonList(new Producer("topicProducer")));
+    topic.setConsumers(Collections.singletonList(new Consumer("topicConsumer-principal")));
+    topic.setProducers(Collections.singletonList(new Producer("topicProducer-principal")));
 
     project.addTopic(topic);
     topology.addProject(project);
@@ -124,10 +126,10 @@ public class PrincipalManagerTest {
     principalManager.applyCreate(topology, plan);
     principalManager.applyDelete(topology, plan);
 
-    Collection<ServiceAccount> accounts =
-        Arrays.asList(
-            new ServiceAccount(-1, "topicConsumer", "Managed by KTB"),
-            new ServiceAccount(-1, "topicProducer", "Managed by KTB"));
+    Set<ServiceAccount> accounts =
+        Sets.newHashSet(
+            new ServiceAccount(-1, "topicConsumer-principal", "Managed by KTB"),
+            new ServiceAccount(-1, "topicProducer-principal", "Managed by KTB"));
 
     assertThat(plan.getActions()).hasSize(1);
     assertThat(plan.getActions()).containsAnyOf(new CreateAccounts(provider, accounts));


### PR DESCRIPTION
Defining mutliple new principals in a descriptor results in mutliple equal ccloud service-account create calls. The first call passes but the subsequent calls cause an error.

Set avoids this, as the ServiceAccount equals is on 'name'; this also being a unique in confluent cloud.

* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING