### PR TITLE
verify CLI parameters as first thing in the process before creating the main handler object

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/JulieOps.java
+++ b/src/main/java/com/purbon/kafka/topology/JulieOps.java
@@ -65,6 +65,7 @@ public class JulieOps implements AutoCloseable {
   public static JulieOps build(String topologyFile, String plansFile, Map<String, String> config)
       throws Exception {
 
+    verifyRequiredParameters(topologyFile, config);
     Configuration builderConfig = Configuration.build(config);
     TopologyBuilderAdminClient adminClient =
         new TopologyBuilderAdminClientBuilder(builderConfig).build();
@@ -83,7 +84,6 @@ public class JulieOps implements AutoCloseable {
             factory.get(),
             factory.builder(),
             principalProviderFactory.get());
-    builder.verifyRequiredParameters(topologyFile, config);
 
     return builder;
   }
@@ -156,7 +156,7 @@ public class JulieOps implements AutoCloseable {
     return new JulieOps(topology, config, topicManager, accessControlManager, principalManager);
   }
 
-  void verifyRequiredParameters(String topologyFile, Map<String, String> config)
+  static void verifyRequiredParameters(String topologyFile, Map<String, String> config)
       throws IOException {
     if (!Files.exists(Paths.get(topologyFile))) {
       throw new IOException("Topology file does not exist");


### PR DESCRIPTION
…he end) of JulieOps.build

A minor bug mentioned in - https://github.com/kafka-ops/julie/pull/252 - deserves its own separate PR.

Generic topology checks (file exists, determining clientConfig path, etc), should be done before creating a JulieOps builder instead of after.

