### PR TITLE
[WiP] dryRun execution supports schema compatibility checks

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -83,6 +83,7 @@ public class ExecutionPlan {
   private void execute(Action action, boolean dryRun) throws IOException {
     LOGGER.debug(String.format("Execution action %s (dryRun=%s)", action, dryRun));
     if (dryRun) {
+      action.dryRun();
       outputStream.println(action);
     } else {
       action.run();

--- a/src/main/java/com/purbon/kafka/topology/actions/Action.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/Action.java
@@ -9,6 +9,10 @@ public interface Action {
 
   void run() throws IOException;
 
+  default void dryRun() throws IOException {
+    System.out.printf("No dryRun check specified for %s", this.getClass().getName());
+  };
+
   default List<TopologyAclBinding> getBindings() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
An initial first code example to improve the the --dryRun functionality. (with a bit of polishing) It solves
https://github.com/kafka-ops/julie/issues/223

Any suggestions on the code? We can keep this PR open to gradually come to a good production ready solution.
