### PR TITLE
#270 support prefix for producer transaction id and consumer group

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
@@ -18,6 +18,11 @@ public class Consumer extends User {
     group = Optional.empty();
   }
 
+  public Consumer(String principal, String group) {
+    super(principal);
+    this.group = Optional.of(group);
+  }
+
   public String groupString() {
     return group.orElse("*");
   }

--- a/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
@@ -14,13 +14,12 @@ public class Consumer extends User {
   }
 
   public Consumer(String principal) {
-    super(principal);
-    group = Optional.empty();
+    this(principal, null);
   }
 
   public Consumer(String principal, String group) {
     super(principal);
-    this.group = Optional.of(group);
+    this.group = Optional.ofNullable(group);
   }
 
   public String groupString() {

--- a/src/main/java/com/purbon/kafka/topology/model/users/Producer.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Producer.java
@@ -16,15 +16,13 @@ public class Producer extends User {
   }
 
   public Producer(String principal) {
-    super(principal);
-    transactionId = Optional.empty();
-    idempotence = Optional.empty();
+    this(principal, null, null);
   }
 
-  public Producer(String principal, String transactionId) {
+  public Producer(String principal, String transactionId, Boolean idempotence) {
     super(principal);
-    this.transactionId = Optional.of(transactionId);
-    idempotence = Optional.of(true);
+    this.transactionId = Optional.ofNullable(transactionId);
+    this.idempotence = Optional.ofNullable(idempotence);
   }
 
   public Optional<String> getTransactionId() {

--- a/src/main/java/com/purbon/kafka/topology/model/users/Producer.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Producer.java
@@ -21,6 +21,12 @@ public class Producer extends User {
     idempotence = Optional.empty();
   }
 
+  public Producer(String principal, String transactionId) {
+    super(principal);
+    this.transactionId = Optional.of(transactionId);
+    idempotence = Optional.of(true);
+  }
+
   public Optional<String> getTransactionId() {
     return transactionId;
   }

--- a/src/test/java/com/purbon/kafka/topology/AclsBindingsBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AclsBindingsBuilderTest.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -88,8 +87,7 @@ public class AclsBindingsBuilderTest {
 
   @Test
   public void testProducerWithTxIdAclsBuilder() {
-    Producer producer = new Producer("User:foo");
-    producer.setTransactionId(Optional.of("1234"));
+    Producer producer = new Producer("User:foo", "1234", true);
     List<TopologyAclBinding> aclBindings =
         builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(5);
@@ -122,8 +120,7 @@ public class AclsBindingsBuilderTest {
 
   @Test
   public void testProducerWithTxIdPrefixAclsBuilder() {
-    Producer producer = new Producer("User:foo", "foo*");
-
+    Producer producer = new Producer("User:foo", "foo*", true);
     List<TopologyAclBinding> aclBindings =
         builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(5);
@@ -150,8 +147,7 @@ public class AclsBindingsBuilderTest {
 
   @Test
   public void testIdempotenceProducerAclsBuilder() {
-    Producer producer = new Producer("User:foo");
-    producer.setIdempotence(Optional.of(true));
+    Producer producer = new Producer("User:foo", null, true);
     List<TopologyAclBinding> aclBindings =
         builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(3);

--- a/src/test/java/com/purbon/kafka/topology/TestTopologyBuilder.java
+++ b/src/test/java/com/purbon/kafka/topology/TestTopologyBuilder.java
@@ -10,7 +10,6 @@ import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.Producer;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -78,8 +77,7 @@ public class TestTopologyBuilder {
   }
 
   public TestTopologyBuilder addConsumer(String user, String group) {
-    Consumer consumer = new Consumer(user);
-    consumer.setGroup(Optional.of(group));
+    Consumer consumer = new Consumer(user, group);
     consumers.add(consumer);
     return this;
   }

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -220,8 +220,7 @@ public class AccessControlManagerIT {
       throws ExecutionException, InterruptedException, IOException {
 
     List<Producer> producers = new ArrayList<>();
-    Producer producer = new Producer("User:Producer12");
-    producer.setTransactionId(Optional.of("1234"));
+    Producer producer = new Producer("User:Producer12", "1234", true);
     producers.add(producer);
 
     Project project = new ProjectImpl("project");
@@ -245,8 +244,7 @@ public class AccessControlManagerIT {
       throws ExecutionException, InterruptedException, IOException {
 
     List<Producer> producers = new ArrayList<>();
-    Producer producer = new Producer("User:Producer13");
-    producer.setIdempotence(Optional.of(true));
+    Producer producer = new Producer("User:Producer13", null, true);
     producers.add(producer);
 
     Project project = new ProjectImpl("project");


### PR DESCRIPTION
Currently producer transaction id and consumer group are treated as literals.  This PR addresses #270 by allowing a trailing * to denote a resource pattern type prefix

```
    consumers:
      - principal: "User:greta"
        group: "greta*"
```
and

```
    producers:
      - principal: "User:greta"
        transactionId: "greta*"
```

Since this is not changing the structure then there should not be any braking changes.  Have added test cases.
