### PR TITLE
Add missing Schema Registry ACLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,7 @@
     <commons.version>1.4</commons.version>
     <mockito.version>3.6.0</mockito.version>
     <junit.version>4.13.1</junit.version>
-    <testcontainers.version>1.15.2</testcontainers.version>
+    <testcontainers.version>1.15.3</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
     <confluent.version>6.1.0</confluent.version>
     <confluent-ce.version>6.1.0-ce</confluent-ce.version>

--- a/src/main/java/com/purbon/kafka/topology/model/users/platform/SchemaRegistryInstance.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/platform/SchemaRegistryInstance.java
@@ -16,8 +16,10 @@ public class SchemaRegistryInstance extends User {
   @JsonInclude(Include.NON_EMPTY)
   private Optional<String> topic;
 
+  @JsonInclude(Include.NON_EMPTY)
   private Optional<String> consumer_offsets_topic;
 
+  @JsonInclude(Include.NON_EMPTY)
   private Optional<String> group;
 
   public SchemaRegistryInstance() {
@@ -31,11 +33,11 @@ public class SchemaRegistryInstance extends User {
   public SchemaRegistryInstance(
       String principal,
       Optional<String> topic,
-      Optional<String> consumerOffsetsTopic,
+      Optional<String> consumer_offsets_topic,
       Optional<String> group) {
     super(principal);
     this.topic = topic;
-    this.consumer_offsets_topic = consumerOffsetsTopic;
+    this.consumer_offsets_topic = consumer_offsets_topic;
     this.group = group;
   }
 
@@ -43,20 +45,20 @@ public class SchemaRegistryInstance extends User {
     return topic.orElse(DEFAULT_SCHEMA_TOPIC);
   }
 
-  public void setTopic(Optional<String> topic) {
-    this.topic = topic;
-  }
-
   public String consumerOffsetsTopicString() {
-    return topic.orElse(DEFAULT_CONSUMER_OFFSETS_TOPIC);
-  }
-
-  public void setConsumerOffsetsTopic(Optional<String> consumerOffsetsTopic) {
-    this.consumer_offsets_topic = consumerOffsetsTopic;
+    return consumer_offsets_topic.orElse(DEFAULT_CONSUMER_OFFSETS_TOPIC);
   }
 
   public String groupString() {
     return group.orElse(DEFAULT_SCHEMA_REGISTRY_GROUP);
+  }
+
+  public void setTopic(Optional<String> topic) {
+    this.topic = topic;
+  }
+
+  public void setConsumer_offsets_topic(Optional<String> consumer_offsets_topic) {
+    this.consumer_offsets_topic = consumer_offsets_topic;
   }
 
   public void setGroup(Optional<String> group) {
@@ -67,7 +69,7 @@ public class SchemaRegistryInstance extends User {
     return topic;
   }
 
-  public Optional<String> getConsumerOffsetsTopic() {
+  public Optional<String> getConsumer_offsets_topic() {
     return consumer_offsets_topic;
   }
 

--- a/src/main/java/com/purbon/kafka/topology/model/users/platform/SchemaRegistryInstance.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/platform/SchemaRegistryInstance.java
@@ -9,10 +9,14 @@ public class SchemaRegistryInstance extends User {
 
   private static final String DEFAULT_SCHEMA_TOPIC = "_schemas";
 
+  private static final String DEFAULT_CONSUMER_OFFSETS_TOPIC = "__consumer_offsets";
+
   private static final String DEFAULT_SCHEMA_REGISTRY_GROUP = "schema-registry";
 
   @JsonInclude(Include.NON_EMPTY)
   private Optional<String> topic;
+
+  private Optional<String> consumer_offsets_topic;
 
   private Optional<String> group;
 
@@ -21,12 +25,17 @@ public class SchemaRegistryInstance extends User {
   }
 
   public SchemaRegistryInstance(String principal) {
-    this(principal, Optional.empty(), Optional.empty());
+    this(principal, Optional.empty(), Optional.empty(), Optional.empty());
   }
 
-  public SchemaRegistryInstance(String principal, Optional<String> topic, Optional<String> group) {
+  public SchemaRegistryInstance(
+      String principal,
+      Optional<String> topic,
+      Optional<String> consumerOffsetsTopic,
+      Optional<String> group) {
     super(principal);
     this.topic = topic;
+    this.consumer_offsets_topic = consumerOffsetsTopic;
     this.group = group;
   }
 
@@ -36,6 +45,14 @@ public class SchemaRegistryInstance extends User {
 
   public void setTopic(Optional<String> topic) {
     this.topic = topic;
+  }
+
+  public String consumerOffsetsTopicString() {
+    return topic.orElse(DEFAULT_CONSUMER_OFFSETS_TOPIC);
+  }
+
+  public void setConsumerOffsetsTopic(Optional<String> consumerOffsetsTopic) {
+    this.consumer_offsets_topic = consumerOffsetsTopic;
   }
 
   public String groupString() {
@@ -48,6 +65,10 @@ public class SchemaRegistryInstance extends User {
 
   public Optional<String> getTopic() {
     return topic;
+  }
+
+  public Optional<String> getConsumerOffsetsTopic() {
+    return consumer_offsets_topic;
   }
 
   public Optional<String> getGroup() {

--- a/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
@@ -230,7 +230,7 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
             principal,
             schemaRegistry.consumerOffsetsTopicString(),
             PatternType.LITERAL,
-            AclOperation.DESCRIBE_CONFIGS));
+            AclOperation.DESCRIBE));
 
     bindings.add(
         buildGroupLevelAcl(

--- a/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
@@ -214,6 +214,7 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
     String principal = translate(schemaRegistry.getPrincipal());
     List<AclBinding> bindings =
         Stream.of(
+                AclOperation.CREATE,
                 AclOperation.DESCRIBE_CONFIGS,
                 AclOperation.DESCRIBE,
                 AclOperation.WRITE,

--- a/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
@@ -213,12 +213,28 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
   private Stream<AclBinding> schemaRegistryAclsStream(SchemaRegistryInstance schemaRegistry) {
     String principal = translate(schemaRegistry.getPrincipal());
     List<AclBinding> bindings =
-        Stream.of(AclOperation.DESCRIBE_CONFIGS, AclOperation.WRITE, AclOperation.READ)
+        Stream.of(
+                AclOperation.DESCRIBE_CONFIGS,
+                AclOperation.DESCRIBE,
+                AclOperation.WRITE,
+                AclOperation.READ)
             .map(
                 aclOperation ->
                     buildTopicLevelAcl(
                         principal, schemaRegistry.topicString(), PatternType.LITERAL, aclOperation))
             .collect(Collectors.toList());
+
+    bindings.add(
+        buildTopicLevelAcl(
+            principal,
+            schemaRegistry.consumerOffsetsTopicString(),
+            PatternType.LITERAL,
+            AclOperation.DESCRIBE_CONFIGS));
+
+    bindings.add(
+        buildGroupLevelAcl(
+            principal, schemaRegistry.groupString(), PatternType.LITERAL, AclOperation.READ));
+
     return bindings.stream();
   }
 

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -509,7 +509,18 @@ public class AccessControlManagerIT {
 
       Collection<AclBinding> acls = kafkaAdminClient.describeAcls(filter).values().get();
 
-      assertEquals(3, acls.size());
+      ResourcePatternFilter groupResourceFilter =
+          new ResourcePatternFilter(ResourceType.GROUP, null, PatternType.ANY);
+
+      AccessControlEntryFilter groupEntryFilter =
+          new AccessControlEntryFilter(
+              sr.getPrincipal(), null, AclOperation.ANY, AclPermissionType.ALLOW);
+      AclBindingFilter groupFilter = new AclBindingFilter(groupResourceFilter, groupEntryFilter);
+
+      Collection<AclBinding> groupAcls = kafkaAdminClient.describeAcls(groupFilter).values().get();
+
+      assertEquals(5, acls.size());
+      assertEquals(1, groupAcls.size());
     }
   }
 

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -519,7 +519,7 @@ public class AccessControlManagerIT {
 
       Collection<AclBinding> groupAcls = kafkaAdminClient.describeAcls(groupFilter).values().get();
 
-      assertEquals(5, acls.size());
+      assertEquals(6, acls.size());
       assertEquals(1, groupAcls.size());
     }
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: Add missing Schema Registry ACLs (#296)

Adds field consumer_offsets_topic under platform schema_registry instances. 

```
platform:
  schema_registry:
    instances:
      - principal: "User:schema_registry"
         topic: "foo"
         consumer_offsets_topic: "foo_offsets"  # new field
         group: "bar"
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Change is now done so that it won't break anything but introduces new fields and additional ACLs that are required for schema-registry principal.


* **Other information**:

topic field is not that descriptive. Should be something like schemas_topic but changing it would make it breaking change. I am not sure is somebody using the functionality currently because I don't see how it would work (without GROUP and required ACLs) ? Therefore could be possible to change the name