### PR TITLE
Fix: Unrecognized field "resource_id" (#307)

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
+++ b/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
@@ -7,15 +7,21 @@ public class ServiceAccount {
   private int id;
   private String name;
   private String description;
+  private String resourceId;
 
   public ServiceAccount() {
-    this(-1, "", "");
+    this(-1, "", "", "");
   }
 
   public ServiceAccount(int id, String name, String description) {
+    this(id, name, description, "");
+  }
+
+  public ServiceAccount(int id, String name, String description, String resourceId) {
     this.id = id;
     this.name = name;
     this.description = description;
+    this.resourceId = resourceId;
   }
 
   public int getId() {
@@ -30,11 +36,16 @@ public class ServiceAccount {
     return description;
   }
 
+  public String getResourceId() {
+    return resourceId;
+  }
+
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("ServiceAccount{");
     sb.append("id=").append(id);
     sb.append(", name='").append(name).append('\'');
+    sb.append(", resourceId='").append(resourceId).append('\'');
     sb.append('}');
     return sb.toString();
   }
@@ -53,6 +64,6 @@ public class ServiceAccount {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), getName(), getDescription());
+    return Objects.hash(getId(), getName(), getDescription(), getResourceId());
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
+++ b/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology.model.cluster;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 public class ServiceAccount {
@@ -7,6 +8,8 @@ public class ServiceAccount {
   private int id;
   private String name;
   private String description;
+
+  @JsonProperty("resource_id")
   private String resourceId;
 
   public ServiceAccount() {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ x] The commit messages are descriptive
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)
- [x ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix:

Added resource_id property to ServiceAccount to remove JSON error.

* **What is the current behavior?** (You can also link to an open issue here)
See https://github.com/kafka-ops/julie/issues/307  

When attempting to manage Confluent Cloud service accounts with the JulieOps CLI tool while using any version of ccloud above v1.27.0, the error message:

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "resource_id" (class com.purbon.kafka.topology.model.cluster.ServiceAccount), not marked as ignorable (3 known properties: "id", "description", "name"])
```

appears in the output.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


