### PR TITLE
Enable the option to pass custom truststore and keystore with custom http clients

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -247,3 +247,21 @@ An example configuration might look like this:
 
 If this prefix list is used, only groups that match the prefix will be ever processed, if wildcard it will be managed if the service account is managed by Julie Ops, anything else will be ignored.
 This is useful in a shared cluster, to avoid Julie Ops removing/accidentally managing group acls by other teams with seperate pipelines.
+
+HTTPs configuration (TLS)
+-----------
+
+JulieOps uses internally the new HttpClient provided since the Java 11 version. If you are aiming to connect into a HTTPs protected endpoint
+you should configure the required truststore and keystore, this as with common kafka clients you can do by using this properties.
+
+* ssl.keystore.location - full path for the store
+* ssl.keystore.password - password for the keystore
+* ssl.truststore.location - full path for the truststore
+* ssl.truststore.password - password for the truststore
+* ssl.key.password - password for the certificate, when required.
+
+ksqlDB manager have specific configuration values for truststore and keystore, but if not specified this ones will be used as default.
+
+**NOTE**: As default JulieOps uses PKCS12 stores, JKS stores are not supported.
+
+This feature is available since version 3.0.0, however if you are willing to use an https connection you could as well define global JVM stores, for more details you can see  https://docs.oracle.com/cd/E29585_01/PlatformServices.61x/security/src/csec_ssl_jsp_start_server.html link.

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -418,10 +418,10 @@ public class Configuration {
     KsqlClientConfig.Builder ksqlConf =
         new KsqlClientConfig.Builder()
             .setServer(getProperty(PLATFORM_SERVER_KSQL_URL))
-            .setTrustStore(getPropertyOrNull(PLATFORM_SERVER_KSQL_TRUSTSTORE))
-            .setTrustStorePassword(getPropertyOrNull(PLATFORM_SERVER_KSQL_TRUSTSTORE_PW))
-            .setKeyStore(getPropertyOrNull(PLATFORM_SERVER_KSQL_KEYSTORE))
-            .setKeyStorePassword(getPropertyOrNull(PLATFORM_SERVER_KSQL_KEYSTORE_PW));
+            .setTrustStore(getPropertyOrNull(PLATFORM_SERVER_KSQL_TRUSTSTORE, SSL_TRUSTSTORE_LOCATION))
+            .setTrustStorePassword(getPropertyOrNull(PLATFORM_SERVER_KSQL_TRUSTSTORE_PW, SSL_TRUSTSTORE_PASSWORD))
+            .setKeyStore(getPropertyOrNull(PLATFORM_SERVER_KSQL_KEYSTORE, SSL_KEYSTORE_LOCATION))
+            .setKeyStorePassword(getPropertyOrNull(PLATFORM_SERVER_KSQL_KEYSTORE_PW, SSL_KEYSTORE_PASSWORD));
     if (hasProperty(PLATFORM_SERVER_KSQL_ALPN)) {
       ksqlConf.setUseAlpn(config.getBoolean(PLATFORM_SERVER_KSQL_ALPN));
     }
@@ -443,10 +443,13 @@ public class Configuration {
     return config.hasPath(PLATFORM_SERVER_KSQL_URL);
   }
 
-  private String getPropertyOrNull(String key) {
+  private String getPropertyOrNull(String key, String defaultKey) {
     try {
       return config.getString(key);
     } catch (ConfigException.Missing e) {
+      if (!defaultKey.isBlank()) {
+        return getPropertyOrNull(defaultKey, "");
+      }
       return null;
     }
   }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -361,6 +361,46 @@ public class Configuration {
     return config.getString(MDS_KC_CLUSTER_ID_CONFIG);
   }
 
+  public Optional<String> getSslTrustStoreLocation() {
+    try {
+      return Optional.of(config.getString(SSL_TRUSTSTORE_LOCATION));
+    } catch (ConfigException.Missing missingEx) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<String> getSslTrustStorePassword() {
+    try {
+      return Optional.of(config.getString(SSL_TRUSTSTORE_PASSWORD));
+    } catch (ConfigException.Missing missingEx) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<String> getSslKeyStoreLocation() {
+    try {
+      return Optional.of(config.getString(SSL_KEYSTORE_LOCATION));
+    } catch (ConfigException.Missing missingEx) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<String> getSslKeyStorePassword() {
+    try {
+      return Optional.of(config.getString(SSL_KEYSTORE_PASSWORD));
+    } catch (ConfigException.Missing missingEx) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<String> getSslKeyPassword() {
+    try {
+      return Optional.of(config.getString(SSL_KEY_PASSWORD));
+    } catch (ConfigException.Missing missingEx) {
+      return Optional.empty();
+    }
+  }
+
   public Map<String, String> getKafkaConnectServers() {
     List<String> servers = config.getStringList(PLATFORM_SERVERS_CONNECT);
     return servers.stream()

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -108,4 +108,11 @@ public class Constants {
 
   public static final String TOPOLOGY_VALIDATIONS_TOPIC_NAME_REGEXP =
       "topology.validations.topic.name.regexp";
+
+  public static final String SSL_TRUSTSTORE_LOCATION = "ssl.truststore.location";
+  public static final String SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
+  public static final String SSL_KEYSTORE_LOCATION = "ssl.keystore.location";
+  public static final String SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
+  public static final String SSL_KEY_PASSWORD = "ssl.key.password";
+
 }

--- a/src/main/java/com/purbon/kafka/topology/JulieOps.java
+++ b/src/main/java/com/purbon/kafka/topology/JulieOps.java
@@ -173,7 +173,7 @@ public class JulieOps implements AutoCloseable {
       Configuration config, String topologyFileOrDir) {
     Map<String, KConnectApiClient> clients =
         config.getKafkaConnectServers().entrySet().stream()
-            .map(entry -> new Pair<>(entry.getKey(), new KConnectApiClient(entry.getValue())))
+            .map(entry -> new Pair<>(entry.getKey(), new KConnectApiClient(entry.getValue(), config)))
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     if (clients.isEmpty()) {

--- a/src/main/java/com/purbon/kafka/topology/api/connect/KConnectApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/connect/KConnectApiClient.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology.api.connect;
 
+import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.api.mds.Response;
 import com.purbon.kafka.topology.clients.ArtefactClient;
 import com.purbon.kafka.topology.clients.JulieHttpClient;
@@ -10,12 +11,17 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class KConnectApiClient extends JulieHttpClient implements ArtefactClient {
 
   public KConnectApiClient(String server) {
     super(server);
+  }
+
+  public KConnectApiClient(String server, Configuration config) {
+    super(server, Optional.of(config));
   }
 
   @Override

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
@@ -4,6 +4,7 @@ import static com.purbon.kafka.topology.api.mds.RequestScope.RESOURCE_NAME;
 import static com.purbon.kafka.topology.api.mds.RequestScope.RESOURCE_PATTERN_TYPE;
 import static com.purbon.kafka.topology.api.mds.RequestScope.RESOURCE_TYPE;
 
+import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.clients.JulieHttpClient;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import com.purbon.kafka.topology.roles.rbac.ClusterLevelRoleBuilder;
@@ -13,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,7 +28,11 @@ public class MDSApiClient extends JulieHttpClient {
   private final ClusterIDs clusterIDs;
 
   public MDSApiClient(String mdsServer) {
-    super(mdsServer);
+    this(mdsServer, Optional.empty());
+  }
+
+  public MDSApiClient(String mdsServer, Optional<Configuration> configOptional) {
+    super(mdsServer, configOptional);
     this.clusterIDs = new ClusterIDs();
   }
 

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClientBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClientBuilder.java
@@ -4,6 +4,8 @@ import com.purbon.kafka.topology.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Optional;
+
 public class MDSApiClientBuilder {
 
   private static final Logger LOGGER = LogManager.getLogger(MDSApiClientBuilder.class);
@@ -17,7 +19,7 @@ public class MDSApiClientBuilder {
   public MDSApiClient build() {
     String mdsServer = config.getMdsServer();
 
-    MDSApiClient apiClient = new MDSApiClient(mdsServer);
+    MDSApiClient apiClient = new MDSApiClient(mdsServer, Optional.of(config));
     // Pass Cluster IDS
     apiClient.setKafkaClusterId(config.getKafkaClusterId());
     apiClient.setSchemaRegistryClusterID(config.getSchemaRegistryClusterId());

--- a/src/test/java/com/purbon/kafka/topology/integration/ConnectApiClientIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/ConnectApiClientIT.java
@@ -20,11 +20,14 @@ public class ConnectApiClientIT {
 
   KConnectApiClient client;
 
+  private static final String TRUSTSTORE_JKS = "/ksql-ssl/truststore/ksqldb.truststore.jks";
+  private static final String KEYSTORE_JKS = "/ksql-ssl/keystore/ksqldb.keystore.jks";
+
   @BeforeClass
   public static void setup() {
     container = ContainerFactory.fetchSaslKafkaContainer(System.getProperty("cp.version"));
     container.start();
-    connectContainer = new ConnectContainer(container);
+    connectContainer = new ConnectContainer(container, TRUSTSTORE_JKS, KEYSTORE_JKS);
     connectContainer.start();
   }
 
@@ -36,7 +39,7 @@ public class ConnectApiClientIT {
 
   @Before
   public void configure() {
-    client = new KConnectApiClient(connectContainer.getUrl());
+    client = new KConnectApiClient(connectContainer.getHttpUrl());
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ConnectContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ConnectContainer.java
@@ -1,6 +1,8 @@
 package com.purbon.kafka.topology.integration.containerutils;
 
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -10,19 +12,25 @@ public class ConnectContainer extends GenericContainer<ConnectContainer> {
       DockerImageName.parse("confluentinc/cp-kafka-connect").withTag("6.0.2");
 
   private static int CONNECT_PORT = 8083;
+  private static int CONNECT_SSL_PORT = 8084;
 
-  public ConnectContainer(AlternativeKafkaContainer kafka) {
-    this(DEFAULT_IMAGE, kafka);
+  public ConnectContainer(AlternativeKafkaContainer kafka,
+                          String truststore,
+                          String keystore) {
+    this(DEFAULT_IMAGE, kafka, truststore, keystore);
   }
 
-  public ConnectContainer(final DockerImageName dockerImageName, AlternativeKafkaContainer kafka) {
+  public ConnectContainer(final DockerImageName dockerImageName,
+                          AlternativeKafkaContainer kafka,
+                          String truststore,
+                          String keystore) {
     super(dockerImageName);
 
     String kafkaHost = kafka.getNetworkAliases().get(1);
-    withExposedPorts(CONNECT_PORT);
+    withExposedPorts(CONNECT_PORT, CONNECT_SSL_PORT);
 
     withEnv("CONNECT_BOOTSTRAP_SERVERS", "SASL_PLAINTEXT://" + kafkaHost + ":" + 9091);
-    withEnv("CONNECT_REST_PORT", String.valueOf(CONNECT_PORT));
+    withEnv("CONNECT_REST_PORT", String.valueOf(CONNECT_SSL_PORT));
     withEnv("CONNECT_GROUP_ID", "kc");
     withEnv("CONNECT_CONFIG_STORAGE_TOPIC", "docker-kafka-connect-cp-configs");
     withEnv("CONNECT_OFFSET_STORAGE_TOPIC", "docker-kafka-connect-cp-offsets");
@@ -34,15 +42,28 @@ public class ConnectContainer extends GenericContainer<ConnectContainer> {
     withEnv("CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR", "1");
     withEnv("CONNECT_STATUS_STORAGE_REPLICATION_FACTOR", "1");
     withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java");
-    withEnv("CONNECT_LISTENERS", "http://0.0.0.0:" + CONNECT_PORT);
+    withEnv("CONNECT_LISTENERS", "http://0.0.0.0:" + CONNECT_PORT + ", https://0.0.0.0:" + CONNECT_SSL_PORT);
 
     withEnv("CONNECT_SASL_JAAS_CONFIG", saslConfig());
     withEnv("CONNECT_SASL_MECHANISM", "PLAIN");
     withEnv("CONNECT_SECURITY_PROTOCOL", "SASL_PLAINTEXT");
+
+    withEnv("CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM", "HTTPS");
+    withEnv("CONNECT_LISTENERS_HTTPS_SSL_TRUSTSTORE_LOCATION", "/etc/kafka-connect/secrets/server.truststore");
+    withEnv("CONNECT_LISTENERS_HTTPS_SSL_TRUSTSTORE_PASSWORD", "ksqldb");
+    withEnv("CONNECT_LISTENERS_HTTPS_SSL_KEYSTORE_LOCATION", "/etc/kafka-connect/secrets/server.keystore");
+    withEnv("CONNECT_LISTENERS_HTTPS_SSL_KEYSTORE_PASSWORD", "ksqldb");
+    withEnv("CONNECT_LISTENERS_HTTPS_SSL_KEY_PASSWORD", "ksqldb");
+
+    this.withClasspathResourceMapping(
+            truststore, "/etc/kafka-connect/secrets/server.truststore", BindMode.READ_ONLY)
+            .withClasspathResourceMapping(
+                    keystore, "/etc/kafka-connect/secrets/server.keystore", BindMode.READ_ONLY);
+
     withNetworkAliases("connect");
     withNetwork(kafka.getNetwork());
 
-    waitingFor(Wait.forHttp("/"));
+    waitingFor((new HttpWaitStrategy()).forPath("/").forPort(CONNECT_PORT));
   }
 
   private String saslConfig() {
@@ -55,7 +76,11 @@ public class ConnectContainer extends GenericContainer<ConnectContainer> {
     return sb.toString();
   }
 
-  public String getUrl() {
+  public String getHttpUrl() {
     return "http://" + getHost() + ":" + getMappedPort(CONNECT_PORT);
+  }
+
+  public String getHttpsUrl() {
+    return "https://" + getHost() + ":" + getMappedPort(CONNECT_SSL_PORT);
   }
 }


### PR DESCRIPTION
Enable the use of custom trusstore and keystore with the base julie http client, so it is not necessary to pass global jvm level stores anymore.

As a user if you pass:

* ssl.keystore.location
* ssl.keystore.password
* ssl.truststore.location
* ssl.truststore.password
* ssl.key.password

note, same as with kafka, this would be used as well when talking with anything Julie uses via a custom HTTP client. This is for now connector API and MDS server. 

As well important, until this change, you need to pass global JVM keystore configuration properties in order to achieve this, something like https://docs.oracle.com/cd/E29585_01/PlatformServices.61x/security/src/csec_ssl_jsp_start_server.html


* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

