### PR TITLE
Enable a feature flag to activate multiple topologies with different context parsing feature

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -527,4 +527,8 @@ public class Configuration {
   public List<String> getDlqTopicsDenyList() {
     return config.getStringList(TOPOLOGY_DQL_TOPICS_DENY_LIST);
   }
+
+  public boolean areMultipleContextPerDirEnabled() {
+    return config.getBoolean(JULIE_ENABLE_MULTIPLE_CONTEXT_PER_DIR);
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -118,6 +118,9 @@ public class Constants {
   public static final String JULIE_GCP_PROJECT_ID = "julie.gcp.project.id";
   public static final String JULIE_GCP_BUCKET = "julie.gcp.bucket";
 
+  public static final String JULIE_ENABLE_MULTIPLE_CONTEXT_PER_DIR =
+      "julie.multiple.context.per.dir.enabled";
+
   public static final String TOPOLOGY_VALIDATIONS_TOPIC_NAME_REGEXP =
       "topology.validations.topic.name.regexp";
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyObjectBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyObjectBuilder.java
@@ -38,6 +38,12 @@ public class TopologyObjectBuilder {
 
     for (Topology topology : topologies) {
       String context = topology.getContext();
+      if (!config.areMultipleContextPerDirEnabled()
+          && (!collection.containsKey(context) && collection.size() == 1)) {
+        // the parsing found a new topology with a different context, as it is not enabled
+        // it should be flag as error
+        throw new IOException("Topologies from different contexts are not allowed");
+      }
       if (!collection.containsKey(context)) {
         collection.put(context, topology);
       } else {

--- a/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACPredefinedRoles.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACPredefinedRoles.java
@@ -5,7 +5,7 @@ public class RBACPredefinedRoles {
   public static final String DEVELOPER_READ = "DeveloperRead";
   public static final String DEVELOPER_WRITE = "DeveloperWrite";
   public static final String DEVELOPER_MANAGE = "DeveloperManage";
-  
+
   public static final String RESOURCE_OWNER = "ResourceOwner";
 
   public static final String SECURITY_ADMIN = "SecurityAdmin";

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -82,6 +82,7 @@ julie {
     s3 {
       endpoint = ""
     }
+    multiple.context.per.dir.enabled = false
 }
 
 confluent {

--- a/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology;
 
 import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
+import static com.purbon.kafka.topology.Constants.JULIE_ENABLE_MULTIPLE_CONTEXT_PER_DIR;
 import static com.purbon.kafka.topology.Constants.PLATFORM_SERVERS_CONNECT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,8 +34,14 @@ public class TopologyObjectBuilderTest {
 
   @Test
   public void buildOutOfMultipleTopos() throws IOException {
+    Map<String, String> cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+    var props = new Properties();
+    props.put(JULIE_ENABLE_MULTIPLE_CONTEXT_PER_DIR, "true");
+    Configuration config = new Configuration(cliOps, props);
+
     String fileOrDirPath = TestUtils.getResourceFilename("/dir_with_multiple");
-    var map = TopologyObjectBuilder.build(fileOrDirPath);
+    var map = TopologyObjectBuilder.build(fileOrDirPath, config);
     assertThat(map).hasSize(2);
     for (var entry : map.entrySet()) {
       assertThat(entry.getValue().getProjects()).hasSize(4);
@@ -65,7 +72,14 @@ public class TopologyObjectBuilderTest {
   }
 
   @Test(expected = IOException.class)
-  public void buildOutOfMultipleProbTopos() throws IOException {
+  public void buildOutOfMultipleToposIfNotEnabled() throws IOException {
+    String fileOrDirPath = TestUtils.getResourceFilename("/dir_with_multiple");
+    TopologyObjectBuilder.build(fileOrDirPath);
+  }
+
+  @Test(expected = IOException.class)
+  public void shouldRaiseAnExceptionIfTryingToParseMultipleTopologiesWithSharedProjects()
+      throws IOException {
     String fileOrDirPath = TestUtils.getResourceFilename("/dir_with_prob");
     TopologyObjectBuilder.build(fileOrDirPath);
   }

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -482,7 +482,6 @@ public class TopologySerdesTest {
     assertEquals("source.contextOrg.foo.bar", p.getTopics().get(1).toString());
   }
 
-
   @Test
   public void testTopologyWithRepeatedAndMissingDataType() {
     Map<String, String> cliOps = new HashMap<>();
@@ -491,14 +490,14 @@ public class TopologySerdesTest {
 
     Properties props = new Properties();
     props.put(
-            TOPIC_PREFIX_FORMAT_CONFIG,
-            "{{context}}.{{project}}.{{topic}}{% if dataType is defined %}.{{dataType}}{% endif %}");
+        TOPIC_PREFIX_FORMAT_CONFIG,
+        "{{context}}.{{project}}.{{topic}}{% if dataType is defined %}.{{dataType}}{% endif %}");
     Configuration config = new Configuration(cliOps, props);
 
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics-datatype.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics-datatype.yaml"));
 
     assertEquals("context", topology.getContext());
 
@@ -523,7 +522,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(4);
@@ -548,7 +547,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(3);
@@ -573,7 +572,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(3);
@@ -597,7 +596,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(3);
@@ -625,7 +624,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(3);
@@ -650,7 +649,7 @@ public class TopologySerdesTest {
     TopologySerdes parser = new TopologySerdes(config, new PlanMap());
 
     Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-only-topics.yaml"));
     Project p = topology.getProjects().get(0);
 
     assertThat(p.getTopics()).hasSize(3);
@@ -663,7 +662,6 @@ public class TopologySerdesTest {
     assertThat(p.getTopics()).hasSize(1);
     assertEquals("contextOrg.source.bar.bar.avro", p.getTopics().get(0).toString());
   }
-
 
   @Test(expected = TopologyParsingException.class)
   public void testTopicNameWithUTFCharacters() {


### PR DESCRIPTION
 by default, only a single context will be possible.
