### PR TITLE
Relax the conditions for kstream application to not require read and write topics all the topic. included as well more easy to catch error messages

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
@@ -396,6 +396,12 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
                 " might require both read and write topics as per its " +
                 "nature it is always reading and writing into Apache Kafka, be aware if you notice problems.");
       }
+      if (topics.get(KStream.READ_TOPICS).isEmpty()) {
+        // should have at minimum read topics defined as we could think of write topics as internal topics being
+        // auto created.
+        throw new IOException("Kafka Streams application with Id "+ks.getApplicationId()+" and principal "+ks.getPrincipal()+
+                " have missing read topics. This field is required.");
+      }
     }
     return Optional.of(new PlatformSystem(streams));
   }

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
@@ -379,9 +379,24 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
   }
 
   private Optional<PlatformSystem> doStreamsElements(JsonParser parser, JsonNode node)
-      throws JsonProcessingException {
+          throws IOException {
     List<KStream> streams =
-        new JsonSerdesUtils<KStream>().parseApplicationUser(parser, node, KStream.class);
+        new JsonSerdesUtils<KStream>().parseApplicationUser(parser, node, KStream.class)
+            .stream()
+            .map(ks -> {
+              ks.getTopics().putIfAbsent(KStream.READ_TOPICS, Collections.emptyList());
+              ks.getTopics().putIfAbsent(KStream.WRITE_TOPICS, Collections.emptyList());
+              return ks;
+            }).collect(Collectors.toList());
+
+    for(KStream ks : streams) {
+      var topics = ks.getTopics();
+      if (topics.get(KStream.READ_TOPICS).isEmpty() || topics.get(KStream.WRITE_TOPICS).isEmpty()) {
+        LOGGER.warn("A Kafka Streams application with Id ("+ks.getApplicationId()+") and Principal ("+ks.getPrincipal()+")" +
+                " might require both read and write topics as per its " +
+                "nature it is always reading and writing into Apache Kafka, be aware if you notice problems.");
+      }
+    }
     return Optional.of(new PlatformSystem(streams));
   }
 

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -71,6 +71,38 @@ public class TopologySerdesTest {
   }
 
   @Test
+  public void testStreamsParsingOnlyReadTopicsShouldNotParseAsNull() {
+    Topology topology =
+            parser.deserialise(TestUtils.getResourceFile("/descriptor-streams-only-read.yaml"));
+
+    Project p = topology.getProjects().get(0);
+
+    for(KStream s : p.getStreams()) {
+      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isNotNull();
+      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isInstanceOf(List.class);
+      assertThat(s.getTopics().get(KStream.READ_TOPICS)).contains("topicA", "topicB");
+      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isNotNull();
+      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isInstanceOf(List.class);
+    }
+  }
+
+  @Test
+  public void testStreamsParsingOnlyWriteTopicsShouldNotParseAsNull() {
+    Topology topology =
+            parser.deserialise(TestUtils.getResourceFile("/descriptor-streams-only-write.yaml"));
+
+    Project p = topology.getProjects().get(0);
+
+    for(KStream s : p.getStreams()) {
+      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isNotNull();
+      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isInstanceOf(List.class);
+      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).contains("topicA", "topicB");
+      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isNotNull();
+      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isInstanceOf(List.class);
+    }
+  }
+
+  @Test
   public void testDynamicFirstLevelAttributes() {
     Topology topology =
         parser.deserialise(TestUtils.getResourceFile("/descriptor-with-others.yml"));

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -86,20 +86,9 @@ public class TopologySerdesTest {
     }
   }
 
-  @Test
-  public void testStreamsParsingOnlyWriteTopicsShouldNotParseAsNull() {
-    Topology topology =
-            parser.deserialise(TestUtils.getResourceFile("/descriptor-streams-only-write.yaml"));
-
-    Project p = topology.getProjects().get(0);
-
-    for(KStream s : p.getStreams()) {
-      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isNotNull();
-      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).isInstanceOf(List.class);
-      assertThat(s.getTopics().get(KStream.WRITE_TOPICS)).contains("topicA", "topicB");
-      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isNotNull();
-      assertThat(s.getTopics().get(KStream.READ_TOPICS)).isInstanceOf(List.class);
-    }
+  @Test(expected = TopologyParsingException.class)
+  public void testStreamsParsingOnlyWriteTopicsShoulRaiseAnException() {
+    parser.deserialise(TestUtils.getResourceFile("/descriptor-streams-only-write.yaml"));
   }
 
   @Test

--- a/src/test/resources/descriptor-streams-only-read.yaml
+++ b/src/test/resources/descriptor-streams-only-read.yaml
@@ -1,0 +1,11 @@
+---
+context: "contextOrg"
+source: "source"
+projects:
+  - name: "foo"
+    streams:
+      - principal: "User:App0"
+        topics:
+          read:
+            - "topicA"
+            - "topicB"

--- a/src/test/resources/descriptor-streams-only-write.yaml
+++ b/src/test/resources/descriptor-streams-only-write.yaml
@@ -1,0 +1,11 @@
+---
+context: "contextOrg"
+source: "source"
+projects:
+  - name: "foo"
+    streams:
+      - principal: "User:App0"
+        topics:
+          write:
+            - "topicA"
+            - "topicB"


### PR DESCRIPTION
Might provide closure for #364, pending discussion 

* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

close #364 

