### PR TITLE
Add env vars for kafka.config.topic and instance.id

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -84,6 +84,8 @@ julie {
     }
     multiple.context.per.dir.enabled = false
     kafka.config.topic = "__julieops_commands"
+    kafka.config.topic = ${?JULIE_KAFKA_CONFIG_TOPIC}
+    instance.id = ${?JULIE_INSTANCE_ID}
 }
 
 confluent {


### PR DESCRIPTION
Add env vars for configuring kafka.config.topic (JULIE_KAFKA_CONFIG_TOPIC) and instance.id (JULIE_INSTANCE_ID), all vars used within the context of the kafka backend.