### PR TITLE
fix: incorrect rbac resource name for subjects and connectors

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/roles/rbac/ClusterLevelRoleBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/rbac/ClusterLevelRoleBuilder.java
@@ -45,7 +45,7 @@ public class ClusterLevelRoleBuilder {
 
     scope = new RequestScope();
     scope.setClusters(clusters);
-    scope.addResource("Subject", "Subject:" + subject, patternType);
+    scope.addResource("Subject", subject, patternType);
     scope.build();
 
     return this;
@@ -59,7 +59,7 @@ public class ClusterLevelRoleBuilder {
 
     scope = new RequestScope();
     scope.setClusters(clusters);
-    scope.addResource("Connector", "Connector:" + connector, patternType);
+    scope.addResource("Connector", connector, patternType);
     scope.build();
 
     return this;

--- a/src/test/java/com/purbon/kafka/topology/api/mds/MDSApiClientTest.java
+++ b/src/test/java/com/purbon/kafka/topology/api/mds/MDSApiClientTest.java
@@ -25,7 +25,7 @@ public class MDSApiClientTest {
     assertThat(mdsRequest.getUrl()).isEqualTo("User:foo/roles/DeveloperRead/bindings");
     assertThat(mdsRequest.getJsonEntity())
         .isEqualTo(
-            "{\"resourcePatterns\":[{\"name\":\"Subject:topic-value\",\"patternType\":\"LITERAL\",\"resourceType\":\"Subject\"}],\"scope\":{\"clusters\":{\"kafka-cluster\":\"\",\"schema-registry-cluster\":\"\"}}}");
+            "{\"resourcePatterns\":[{\"name\":\"topic-value\",\"patternType\":\"LITERAL\",\"resourceType\":\"Subject\"}],\"scope\":{\"clusters\":{\"kafka-cluster\":\"\",\"schema-registry-cluster\":\"\"}}}");
   }
 
   @Test
@@ -41,6 +41,25 @@ public class MDSApiClientTest {
     assertThat(mdsRequest.getUrl()).isEqualTo("User:foo/roles/DeveloperRead/bindings");
     assertThat(mdsRequest.getJsonEntity())
         .isEqualTo(
-            "{\"resourcePatterns\":[{\"name\":\"Subject:topic-value\",\"patternType\":\"LITERAL\",\"resourceType\":\"Subject\"}],\"scope\":{\"clusters\":{\"kafka-cluster\":\"\",\"schema-registry-cluster\":\"\"}}}");
+            "{\"resourcePatterns\":[{\"name\":\"topic-value\",\"patternType\":\"LITERAL\",\"resourceType\":\"Subject\"}],\"scope\":{\"clusters\":{\"kafka-cluster\":\"\",\"schema-registry-cluster\":\"\"}}}");
+  }
+
+  @Test
+  public void testBindConnectRole() {
+    String principal = "User:foo";
+    String connectorName = "jdbc-sink";
+
+    TopologyAclBinding binding =
+        apiClient
+            .bind(principal, DEVELOPER_READ)
+            .forAKafkaConnector(connectorName)
+            .apply("Connector", connectorName);
+
+    MDSRequest mdsRequest = apiClient.buildRequest(binding);
+
+    assertThat(mdsRequest.getUrl()).isEqualTo("User:foo/roles/DeveloperRead/bindings");
+    assertThat(mdsRequest.getJsonEntity())
+        .isEqualTo(
+            "{\"resourcePatterns\":[{\"name\":\"jdbc-sink\",\"patternType\":\"LITERAL\",\"resourceType\":\"Connector\"}],\"scope\":{\"clusters\":{\"kafka-cluster\":\"\",\"connect-cluster\":\"\"}}}");
   }
 }


### PR DESCRIPTION
Fix incorrect Confluent RBAC resource name for subjects and connectors.

close #402 #399 #375 #286 