### PR TITLE
Fix: Topic config values should take precedence over plan config values

### DIFF
--- a/docs/futures/use-of-custom-config-plans.rst
+++ b/docs/futures/use-of-custom-config-plans.rst
@@ -68,7 +68,7 @@ In this Topology the topics *fooBar*, *barFoo* and *barFooBar* will be using cus
 
 **Things to consider**:
 
-* Configuration values defined in the plan take precedence over the config values defined in the topic.
+* Configuration values defined in the topic take precedence over the config values defined plan.
 * A topic can have only a plan, without providing any configuration.
 * The Plan label is optional, topics can use, or not, plans.
 * If plans are defined in the Topology, but no proper definition file is passed, the tool will complain.

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
@@ -85,7 +85,7 @@ public class TopicCustomDeserializer extends StdDeserializer<TopicImpl> {
           String planLabel = jsonNode.asText();
           if (plans.containsKey(planLabel)) {
             Map<String, String> planConfigObject = plans.get(planLabel).getConfig();
-            planConfigObject.forEach(config::put);
+            planConfigObject.forEach(config::putIfAbsent);
           } else {
             LOGGER.warn(planLabel + " is missing in the plans definition. It will be ignored.");
           }

--- a/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
@@ -51,7 +51,7 @@ public class TopologyObjectBuilderTest {
     // should overwide values with priority given to the plans
     topic = map.get("barFooBar");
     assertThat(topic.getConfig()).containsEntry("replication.factor", "1");
-    assertThat(topic.getConfig()).containsEntry("bar", "3");
+    assertThat(topic.getConfig()).containsEntry("bar", "1");
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR fix issue #409 

Configuration values are now updated with plan values only if they do not already exist.