### PR TITLE
fix/feature: make service accounts prefix filter a primary criteria when available to filter the list of access control rules

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -281,8 +281,8 @@ public class AccessControlManager implements ManagerOfThings {
     String resourceName = topologyAclBinding.getResourceName();
     String principle = topologyAclBinding.getPrincipal();
     // For global wild cards ACL's we manage only if we manage the service account/principle,
-    // regardless.
-    if (resourceName.equals("*")) {
+    // regardless. Filtering by service account will always take precedence if defined
+    if (haveServiceAccountPrefixFilters() || resourceName.equals("*")) {
       return matchesServiceAccountPrefixList(principle);
     }
 
@@ -290,9 +290,8 @@ public class AccessControlManager implements ManagerOfThings {
       return matchesTopicPrefixList(resourceName);
     } else if ("GROUP".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
       return matchesGroupPrefixList(resourceName);
-    } else {
-      return matchesServiceAccountPrefixList(principle);
     }
+    return true; // should include everything if not properly excluded earlier.
   }
 
   private boolean matchesTopicPrefixList(String topic) {
@@ -305,6 +304,10 @@ public class AccessControlManager implements ManagerOfThings {
 
   private boolean matchesServiceAccountPrefixList(String principal) {
     return matchesPrefix(managedServiceAccountPrefixes, principal, "Principal");
+  }
+
+  private boolean haveServiceAccountPrefixFilters() {
+    return managedServiceAccountPrefixes.size() != 0;
   }
 
   private boolean matchesPrefix(List<String> prefixes, String item, String type) {

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
@@ -117,6 +117,16 @@ public class MDSApiClient extends JulieHttpClient {
     }
   }
 
+  /**
+   * Create an RBAC resource binding
+   *
+   * @param principal
+   * @param role
+   * @param resource
+   * @param resourceType
+   * @param patternType
+   * @return TopologyAclBinding
+   */
   public TopologyAclBinding bind(
       String principal, String role, String resource, String resourceType, String patternType) {
 


### PR DESCRIPTION
close #381