### PR TITLE
Throw exception for invalid plan name

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
@@ -87,7 +87,7 @@ public class TopicCustomDeserializer extends StdDeserializer<Topic> {
             planConfigObject.forEach(config::putIfAbsent);
           } else {
             throw new TopologyParsingException(
-                "Topic \"" + name "\" references non-existing plan \"" + planLabel + "\"");
+                "Topic \"" + name + "\" references non-existing plan \"" + planLabel + "\"");
           }
         });
     Topic topic = new Topic(name, producers, consumers, optionalDataType, config, this.config);

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
@@ -87,7 +87,7 @@ public class TopicCustomDeserializer extends StdDeserializer<Topic> {
             planConfigObject.forEach(config::putIfAbsent);
           } else {
             throw new TopologyParsingException(
-                "Reference to non-existing plan \"" + planLabel + "\"");
+                "Topic \"" + name "\" references non-existing plan \"" + planLabel + "\"");
           }
         });
     Topic topic = new Topic(name, producers, consumers, optionalDataType, config, this.config);

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.exceptions.TopologyParsingException;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.PlanMap;
 import com.purbon.kafka.topology.model.SubjectNameStrategy;
@@ -85,10 +86,10 @@ public class TopicCustomDeserializer extends StdDeserializer<Topic> {
             Map<String, String> planConfigObject = plans.get(planLabel).getConfig();
             planConfigObject.forEach(config::putIfAbsent);
           } else {
-            LOGGER.warn(planLabel + " is missing in the plans definition. It will be ignored.");
+            throw new TopologyParsingException(
+                "Reference to non-existing plan \"" + planLabel + "\"");
           }
         });
-
     Topic topic = new Topic(name, producers, consumers, optionalDataType, config, this.config);
 
     Optional<SubjectNameStrategy> subjectNameStrategy =

--- a/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
@@ -147,6 +147,13 @@ public class TopologyObjectBuilderTest {
   }
 
   @Test(expected = TopologyParsingException.class)
+  public void testTopologyWithInvalidPlan() throws IOException {
+    String descriptorFile = TestUtils.getResourceFilename("/descriptor-with-invalid-plan.yaml");
+    String plansFile = TestUtils.getResourceFilename("/plans.yaml");
+    TopologyObjectBuilder.build(descriptorFile, plansFile);
+  }
+
+  @Test(expected = TopologyParsingException.class)
   public void testInvalidTopology() throws IOException {
     String descriptorFile =
         TestUtils.getResourceFilename("/errors_dir/descriptor-with-errors.yaml");

--- a/src/test/resources/descriptor-with-invalid-plan.yaml
+++ b/src/test/resources/descriptor-with-invalid-plan.yaml
@@ -1,0 +1,10 @@
+---
+context: "contextOrg"
+source: "source"
+projects:
+  - name: "foo"
+    topics:
+      - name: "fooBar"
+        plan: "gold"
+      - name: "barFoo"
+        plan: "invalid-plan-name"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

We have had a couple of incidents where people have misspelled the plan name. JulieOps logs a warning about this and falls back to default configuration. Nobody sees the warning, so the result is incorrectly configured topics that nobody notices before it is too late.

I think it makes no sense to let people specify a plan that does not exist, so this PR will change the warning to an exception.
