### PR TITLE
Detect divergences between local state and the remote cluster current status

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -7,6 +7,7 @@ import com.purbon.kafka.topology.actions.access.ClearBindings;
 import com.purbon.kafka.topology.actions.access.CreateBindings;
 import com.purbon.kafka.topology.actions.access.builders.*;
 import com.purbon.kafka.topology.actions.access.builders.rbac.*;
+import com.purbon.kafka.topology.exceptions.RemoteValidationException;
 import com.purbon.kafka.topology.model.Component;
 import com.purbon.kafka.topology.model.DynamicUser;
 import com.purbon.kafka.topology.model.JulieRoles;
@@ -104,7 +105,8 @@ public class AccessControlManager implements ExecutionPlanUpdater {
     return currentState;
   }
 
-  private void detectDivergencesInTheRemoteCluster(ExecutionPlan plan) throws IOException {
+  private void detectDivergencesInTheRemoteCluster(ExecutionPlan plan)
+      throws RemoteValidationException {
     var remoteAcls = providerBindings();
 
     var delta =
@@ -118,7 +120,7 @@ public class AccessControlManager implements ExecutionPlanUpdater {
               + StringUtils.join(delta, ",")
               + " are in your local state, but not in the cluster, please investigate!";
       LOGGER.error(errorMessage);
-      throw new IOException(errorMessage);
+      throw new RemoteValidationException(errorMessage);
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/KSqlArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/KSqlArtefactManager.java
@@ -27,141 +27,140 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class KSqlArtefactManager extends ArtefactManager {
 
-    private static final Logger LOGGER = LogManager.getLogger(KSqlArtefactManager.class);
+  private static final Logger LOGGER = LogManager.getLogger(KSqlArtefactManager.class);
 
-    public KSqlArtefactManager(
-            ArtefactClient client, Configuration config, String topologyFileOrDir) {
-        super(client, config, topologyFileOrDir);
+  public KSqlArtefactManager(
+      ArtefactClient client, Configuration config, String topologyFileOrDir) {
+    super(client, config, topologyFileOrDir);
+  }
+
+  public KSqlArtefactManager(
+      Map<String, ? extends ArtefactClient> clients,
+      Configuration config,
+      String topologyFileOrDir) {
+    super(clients, config, topologyFileOrDir);
+  }
+
+  @Override
+  protected Collection<? extends Artefact> getLocalState(ExecutionPlan plan) {
+    return plan.getKSqlArtefacts();
+  }
+
+  @Override
+  protected List<? extends Artefact> findArtefactsToBeDeleted(
+      Collection<? extends Artefact> currentArtefacts, Set<Artefact> artefacts) {
+
+    var artefactsList =
+        currentArtefacts.stream()
+            .filter(a -> !artefacts.contains(a))
+            .sorted((o1, o2) -> -1 * ((KsqlArtefact) o1).compareTo((KsqlArtefact) o2))
+            .collect(Collectors.toCollection(LinkedList::new));
+
+    Map<String, LinkedList<KsqlArtefact>> artefactsMap = new HashMap<>();
+    artefactsMap.put("table", new LinkedList<>());
+    artefactsMap.put("stream", new LinkedList<>());
+
+    artefactsList.forEach(
+        (Consumer<Artefact>)
+            artefact -> {
+              if (artefact instanceof KsqlTableArtefact) {
+                artefactsMap.get("table").add((KsqlArtefact) artefact);
+              } else {
+                artefactsMap.get("stream").add((KsqlArtefact) artefact);
+              }
+            });
+
+    LinkedList<KsqlArtefact> toDeleteArtefactsList = new LinkedList<>();
+    for (String key : Arrays.asList("table", "stream")) {
+      artefactsMap.get(key).descendingIterator().forEachRemaining(toDeleteArtefactsList::add);
+    }
+    return toDeleteArtefactsList;
+  }
+
+  @Override
+  protected Collection<? extends Artefact> getClustersState() throws IOException {
+    List<Either> list =
+        clients.values().stream()
+            .map(
+                client -> {
+                  try {
+                    Collection<? extends Artefact> artefacts = client.getClusterState();
+                    if (artefacts.isEmpty()) {
+                      return Either.Right(null);
+                    }
+                    return Either.Right(artefacts);
+                  } catch (IOException ex) {
+                    return Either.Left(ex);
+                  }
+                })
+            .collect(Collectors.toList());
+
+    List<IOException> errors =
+        list.stream()
+            .filter(Either::isLeft)
+            .map(e -> (IOException) e.getLeft().get())
+            .collect(Collectors.toList());
+    if (errors.size() > 0) {
+      throw new IOException(errors.get(0));
     }
 
-    public KSqlArtefactManager(
-            Map<String, ? extends ArtefactClient> clients,
-            Configuration config,
-            String topologyFileOrDir) {
-        super(clients, config, topologyFileOrDir);
-    }
+    return list.stream()
+        .filter(Either::isRight)
+        .flatMap(
+            (Function<Either, Stream<? extends Artefact>>)
+                either -> {
+                  Collection<? extends Artefact> artefacts =
+                      (Collection<? extends Artefact>) either.getRight().get();
+                  return artefacts.stream();
+                })
+        .map(
+            artefact -> {
+              if (artefact instanceof KsqlStreamArtefact) {
+                return new KsqlStreamArtefact(artefact.getPath(), null, artefact.getName());
+              } else if (artefact instanceof KsqlTableArtefact) {
+                return new KsqlTableArtefact(artefact.getPath(), null, artefact.getName());
+              } else {
+                LOGGER.error("KSQL Artefact of wrong type " + artefact.getClass());
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
 
-    @Override
-    protected Collection<? extends Artefact> getLocalState(ExecutionPlan plan) {
-        return plan.getKSqlArtefacts();
-    }
+  @Override
+  Set<Artefact> parseNewArtefacts(Topology topology) {
+    return topology.getProjects().stream()
+        .flatMap(
+            (Function<Project, Stream<Artefact>>)
+                project -> {
+                  KsqlArtefacts kSql = project.getKsqlArtefacts();
+                  return Stream.concat(kSql.getStreams().stream(), kSql.getTables().stream());
+                })
+        .sorted()
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
 
-    @Override
-    protected List<? extends Artefact> findArtefactsToBeDeleted(
-            Collection<? extends Artefact> currentArtefacts, Set<Artefact> artefacts) {
+  @Override
+  boolean isAllowDelete() {
+    return config.isAllowDeleteKsqlArtefacts();
+  }
 
-        var artefactsList =
-                currentArtefacts.stream()
-                        .filter(a -> !artefacts.contains(a))
-                        .sorted((o1, o2) -> -1 * ((KsqlArtefact) o1).compareTo((KsqlArtefact) o2))
-                        .collect(Collectors.toCollection(LinkedList::new));
+  @Override
+  String rootPath() {
+    return Files.isDirectory(Paths.get(topologyFileOrDir))
+        ? topologyFileOrDir
+        : new File(topologyFileOrDir).getParent();
+  }
 
-        Map<String, LinkedList<KsqlArtefact>> artefactsMap = new HashMap<>();
-        artefactsMap.put("table", new LinkedList<>());
-        artefactsMap.put("stream", new LinkedList<>());
-
-        artefactsList.forEach(
-                (Consumer<Artefact>)
-                        artefact -> {
-                            if (artefact instanceof KsqlTableArtefact) {
-                                artefactsMap.get("table").add((KsqlArtefact) artefact);
-                            } else {
-                                artefactsMap.get("stream").add((KsqlArtefact) artefact);
-                            }
-                        });
-
-        LinkedList<KsqlArtefact> toDeleteArtefactsList = new LinkedList<>();
-        for (String key : Arrays.asList("table", "stream")) {
-            artefactsMap.get(key).descendingIterator().forEachRemaining(toDeleteArtefactsList::add);
-        }
-        return toDeleteArtefactsList;
-    }
-
-    @Override
-    protected Collection<? extends Artefact> getClustersState() throws IOException {
-        List<Either> list =
-                clients.values().stream()
-                        .map(
-                                client -> {
-                                    try {
-                                        Collection<? extends Artefact> artefacts = client.getClusterState();
-                                        if (artefacts.isEmpty()) {
-                                            return Either.Right(null);
-                                        }
-                                        return Either.Right(artefacts);
-                                    } catch (IOException ex) {
-                                        return Either.Left(ex);
-                                    }
-                                })
-                        .collect(Collectors.toList());
-
-        List<IOException> errors =
-                list.stream()
-                        .filter(Either::isLeft)
-                        .map(e -> (IOException) e.getLeft().get())
-                        .collect(Collectors.toList());
-        if (errors.size() > 0) {
-            throw new IOException(errors.get(0));
-        }
-
-        return list.stream()
-                .filter(Either::isRight)
-                .flatMap(
-                        (Function<Either, Stream<? extends Artefact>>)
-                                either -> {
-                                    Collection<? extends Artefact> artefacts =
-                                            (Collection<? extends Artefact>) either.getRight().get();
-                                    return artefacts.stream();
-                                })
-                .map(
-                        artefact -> {
-                            if (artefact instanceof KsqlStreamArtefact) {
-                                return new KsqlStreamArtefact(artefact.getPath(), null, artefact.getName());
-                            } else if (artefact instanceof KsqlTableArtefact) {
-                                return new KsqlTableArtefact(artefact.getPath(), null, artefact.getName());
-                            } else {
-                                LOGGER.error("KSQL Artefact of wrong type " + artefact.getClass());
-                                return null;
-                            }
-                        })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-    }
-
-    @Override
-    Set<Artefact> parseNewArtefacts(Topology topology) {
-        return topology.getProjects().stream()
-                .flatMap(
-                        (Function<Project, Stream<Artefact>>)
-                                project -> {
-                                    KsqlArtefacts kSql = project.getKsqlArtefacts();
-                                    return Stream.concat(kSql.getStreams().stream(), kSql.getTables().stream());
-                                })
-                .sorted()
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    @Override
-    boolean isAllowDelete() {
-        return config.isAllowDeleteKsqlArtefacts();
-    }
-
-    @Override
-    String rootPath() {
-        return Files.isDirectory(Paths.get(topologyFileOrDir))
-                ? topologyFileOrDir
-                : new File(topologyFileOrDir).getParent();
-    }
-
-    @Override
-    public void printCurrentState(PrintStream out) throws IOException {
-        out.println("List of KSQL Artifacts:");
-        getClustersState().forEach(out::println);
-    }
+  @Override
+  public void printCurrentState(PrintStream out) throws IOException {
+    out.println("List of KSQL Artifacts:");
+    getClustersState().forEach(out::println);
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/KSqlArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/KSqlArtefactManager.java
@@ -33,162 +33,135 @@ import org.apache.logging.log4j.Logger;
 
 public class KSqlArtefactManager extends ArtefactManager {
 
-  private static final Logger LOGGER = LogManager.getLogger(KSqlArtefactManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(KSqlArtefactManager.class);
 
-  public KSqlArtefactManager(
-      ArtefactClient client, Configuration config, String topologyFileOrDir) {
-    super(client, config, topologyFileOrDir);
-  }
-
-  public KSqlArtefactManager(
-      Map<String, ? extends ArtefactClient> clients,
-      Configuration config,
-      String topologyFileOrDir) {
-    super(clients, config, topologyFileOrDir);
-  }
-
-  @Override
-  Collection<? extends Artefact> loadActualClusterStateIfAvailable(ExecutionPlan plan)
-      throws IOException {
-    var currentState =
-        config.fetchStateFromTheCluster() ? getClustersState() : plan.getKSqlArtefacts();
-
-    if (!config.fetchStateFromTheCluster()) {
-      // should detect if there are divergences between the local cluster state and the current
-      // status in the cluster
-      detectDivergencesInTheRemoteCluster(plan);
+    public KSqlArtefactManager(
+            ArtefactClient client, Configuration config, String topologyFileOrDir) {
+        super(client, config, topologyFileOrDir);
     }
 
-    return currentState;
-  }
-
-  private void detectDivergencesInTheRemoteCluster(ExecutionPlan plan) throws IOException {
-    var remoteArtefacts = getClustersState();
-
-    var delta =
-        plan.getKSqlArtefacts().stream()
-            .filter(localArtefacts -> !remoteArtefacts.contains(localArtefacts))
-            .collect(Collectors.toList());
-
-    if (delta.size() > 0) {
-      String errorMessage =
-          "Your remote state has changed since the last execution, these ksqlDB Artifact(s): "
-              + StringUtils.join(delta, ",")
-              + " are in your local state, but not in the cluster, please investigate!";
-      LOGGER.error(errorMessage);
-      throw new IOException(errorMessage);
-    }
-  }
-
-  @Override
-  protected List<? extends Artefact> findArtefactsToBeDeleted(
-      Collection<? extends Artefact> currentArtefacts, Set<Artefact> artefacts) {
-
-    var artefactsList =
-        currentArtefacts.stream()
-            .filter(a -> !artefacts.contains(a))
-            .sorted((o1, o2) -> -1 * ((KsqlArtefact) o1).compareTo((KsqlArtefact) o2))
-            .collect(Collectors.toCollection(LinkedList::new));
-
-    Map<String, LinkedList<KsqlArtefact>> artefactsMap = new HashMap<>();
-    artefactsMap.put("table", new LinkedList<>());
-    artefactsMap.put("stream", new LinkedList<>());
-
-    artefactsList.forEach(
-        (Consumer<Artefact>)
-            artefact -> {
-              if (artefact instanceof KsqlTableArtefact) {
-                artefactsMap.get("table").add((KsqlArtefact) artefact);
-              } else {
-                artefactsMap.get("stream").add((KsqlArtefact) artefact);
-              }
-            });
-
-    LinkedList<KsqlArtefact> toDeleteArtefactsList = new LinkedList<>();
-    for (String key : Arrays.asList("table", "stream")) {
-      artefactsMap.get(key).descendingIterator().forEachRemaining(toDeleteArtefactsList::add);
-    }
-    return toDeleteArtefactsList;
-  }
-
-  private Collection<? extends Artefact> getClustersState() throws IOException {
-    List<Either> list =
-        clients.values().stream()
-            .map(
-                client -> {
-                  try {
-                    Collection<? extends Artefact> artefacts = client.getClusterState();
-                    if (artefacts.isEmpty()) {
-                      return Either.Right(null);
-                    }
-                    return Either.Right(artefacts);
-                  } catch (IOException ex) {
-                    return Either.Left(ex);
-                  }
-                })
-            .collect(Collectors.toList());
-
-    List<IOException> errors =
-        list.stream()
-            .filter(Either::isLeft)
-            .map(e -> (IOException) e.getLeft().get())
-            .collect(Collectors.toList());
-    if (errors.size() > 0) {
-      throw new IOException(errors.get(0));
+    public KSqlArtefactManager(
+            Map<String, ? extends ArtefactClient> clients,
+            Configuration config,
+            String topologyFileOrDir) {
+        super(clients, config, topologyFileOrDir);
     }
 
-    return list.stream()
-        .filter(Either::isRight)
-        .flatMap(
-            (Function<Either, Stream<? extends Artefact>>)
-                either -> {
-                  Collection<? extends Artefact> artefacts =
-                      (Collection<? extends Artefact>) either.getRight().get();
-                  return artefacts.stream();
-                })
-        .map(
-            artefact -> {
-              if (artefact instanceof KsqlStreamArtefact) {
-                return new KsqlStreamArtefact(artefact.getPath(), null, artefact.getName());
-              } else if (artefact instanceof KsqlTableArtefact) {
-                return new KsqlTableArtefact(artefact.getPath(), null, artefact.getName());
-              } else {
-                LOGGER.error("KSQL Artefact of wrong type " + artefact.getClass());
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toSet());
-  }
+    @Override
+    protected Collection<? extends Artefact> getLocalState(ExecutionPlan plan) {
+        return plan.getKSqlArtefacts();
+    }
 
-  @Override
-  Set<Artefact> parseNewArtefacts(Topology topology) {
-    return topology.getProjects().stream()
-        .flatMap(
-            (Function<Project, Stream<Artefact>>)
-                project -> {
-                  KsqlArtefacts kSql = project.getKsqlArtefacts();
-                  return Stream.concat(kSql.getStreams().stream(), kSql.getTables().stream());
-                })
-        .sorted()
-        .collect(Collectors.toCollection(LinkedHashSet::new));
-  }
+    @Override
+    protected List<? extends Artefact> findArtefactsToBeDeleted(
+            Collection<? extends Artefact> currentArtefacts, Set<Artefact> artefacts) {
 
-  @Override
-  boolean isAllowDelete() {
-    return config.isAllowDeleteKsqlArtefacts();
-  }
+        var artefactsList =
+                currentArtefacts.stream()
+                        .filter(a -> !artefacts.contains(a))
+                        .sorted((o1, o2) -> -1 * ((KsqlArtefact) o1).compareTo((KsqlArtefact) o2))
+                        .collect(Collectors.toCollection(LinkedList::new));
 
-  @Override
-  String rootPath() {
-    return Files.isDirectory(Paths.get(topologyFileOrDir))
-        ? topologyFileOrDir
-        : new File(topologyFileOrDir).getParent();
-  }
+        Map<String, LinkedList<KsqlArtefact>> artefactsMap = new HashMap<>();
+        artefactsMap.put("table", new LinkedList<>());
+        artefactsMap.put("stream", new LinkedList<>());
 
-  @Override
-  public void printCurrentState(PrintStream out) throws IOException {
-    out.println("List of KSQL Artifacts:");
-    getClustersState().forEach(out::println);
-  }
+        artefactsList.forEach(
+                (Consumer<Artefact>)
+                        artefact -> {
+                            if (artefact instanceof KsqlTableArtefact) {
+                                artefactsMap.get("table").add((KsqlArtefact) artefact);
+                            } else {
+                                artefactsMap.get("stream").add((KsqlArtefact) artefact);
+                            }
+                        });
+
+        LinkedList<KsqlArtefact> toDeleteArtefactsList = new LinkedList<>();
+        for (String key : Arrays.asList("table", "stream")) {
+            artefactsMap.get(key).descendingIterator().forEachRemaining(toDeleteArtefactsList::add);
+        }
+        return toDeleteArtefactsList;
+    }
+
+    @Override
+    protected Collection<? extends Artefact> getClustersState() throws IOException {
+        List<Either> list =
+                clients.values().stream()
+                        .map(
+                                client -> {
+                                    try {
+                                        Collection<? extends Artefact> artefacts = client.getClusterState();
+                                        if (artefacts.isEmpty()) {
+                                            return Either.Right(null);
+                                        }
+                                        return Either.Right(artefacts);
+                                    } catch (IOException ex) {
+                                        return Either.Left(ex);
+                                    }
+                                })
+                        .collect(Collectors.toList());
+
+        List<IOException> errors =
+                list.stream()
+                        .filter(Either::isLeft)
+                        .map(e -> (IOException) e.getLeft().get())
+                        .collect(Collectors.toList());
+        if (errors.size() > 0) {
+            throw new IOException(errors.get(0));
+        }
+
+        return list.stream()
+                .filter(Either::isRight)
+                .flatMap(
+                        (Function<Either, Stream<? extends Artefact>>)
+                                either -> {
+                                    Collection<? extends Artefact> artefacts =
+                                            (Collection<? extends Artefact>) either.getRight().get();
+                                    return artefacts.stream();
+                                })
+                .map(
+                        artefact -> {
+                            if (artefact instanceof KsqlStreamArtefact) {
+                                return new KsqlStreamArtefact(artefact.getPath(), null, artefact.getName());
+                            } else if (artefact instanceof KsqlTableArtefact) {
+                                return new KsqlTableArtefact(artefact.getPath(), null, artefact.getName());
+                            } else {
+                                LOGGER.error("KSQL Artefact of wrong type " + artefact.getClass());
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    Set<Artefact> parseNewArtefacts(Topology topology) {
+        return topology.getProjects().stream()
+                .flatMap(
+                        (Function<Project, Stream<Artefact>>)
+                                project -> {
+                                    KsqlArtefacts kSql = project.getKsqlArtefacts();
+                                    return Stream.concat(kSql.getStreams().stream(), kSql.getTables().stream());
+                                })
+                .sorted()
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    @Override
+    boolean isAllowDelete() {
+        return config.isAllowDeleteKsqlArtefacts();
+    }
+
+    @Override
+    String rootPath() {
+        return Files.isDirectory(Paths.get(topologyFileOrDir))
+                ? topologyFileOrDir
+                : new File(topologyFileOrDir).getParent();
+    }
+
+    @Override
+    public void printCurrentState(PrintStream out) throws IOException {
+        out.println("List of KSQL Artifacts:");
+        getClustersState().forEach(out::println);
+    }
 }

--- a/src/main/java/com/purbon/kafka/topology/KafkaConnectArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaConnectArtefactManager.java
@@ -15,8 +15,13 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class KafkaConnectArtefactManager extends ArtefactManager {
+
+  private static final Logger LOGGER = LogManager.getLogger(KafkaConnectArtefactManager.class);
 
   public KafkaConnectArtefactManager(
       ArtefactClient client, Configuration config, String topologyFileOrDir) {
@@ -31,7 +36,34 @@ public class KafkaConnectArtefactManager extends ArtefactManager {
   @Override
   Collection<? extends Artefact> loadActualClusterStateIfAvailable(ExecutionPlan plan)
       throws IOException {
-    return config.fetchStateFromTheCluster() ? getClustersState() : plan.getConnectors();
+    var currentState =
+        config.fetchStateFromTheCluster() ? getClustersState() : plan.getConnectors();
+
+    if (!config.fetchStateFromTheCluster()) {
+      // should detect if there are divergences between the local cluster state and the current
+      // status in the cluster
+      detectDivergencesInTheRemoteCluster(plan);
+    }
+
+    return currentState;
+  }
+
+  private void detectDivergencesInTheRemoteCluster(ExecutionPlan plan) throws IOException {
+    var remoteConnectors = getClustersState();
+
+    var delta =
+        plan.getConnectors().stream()
+            .filter(localConnector -> !remoteConnectors.contains(localConnector))
+            .collect(Collectors.toList());
+
+    if (delta.size() > 0) {
+      String errorMessage =
+          "Your remote state has changed since the last execution, these Connector(s): "
+              + StringUtils.join(delta, ",")
+              + " are in your local state, but not in the cluster, please investigate!";
+      LOGGER.error(errorMessage);
+      throw new IOException(errorMessage);
+    }
   }
 
   private Collection<? extends Artefact> getClustersState() throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/KafkaConnectArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaConnectArtefactManager.java
@@ -15,7 +15,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/com/purbon/kafka/topology/TopicManager.java
+++ b/src/main/java/com/purbon/kafka/topology/TopicManager.java
@@ -8,6 +8,7 @@ import com.purbon.kafka.topology.actions.topics.TopicConfigUpdatePlan;
 import com.purbon.kafka.topology.actions.topics.UpdateTopicConfigAction;
 import com.purbon.kafka.topology.actions.topics.builders.TopicConfigUpdatePlanBuilder;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.exceptions.RemoteValidationException;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.schemas.SchemaRegistryManager;
@@ -148,7 +149,7 @@ public class TopicManager implements ExecutionPlanUpdater {
               + StringUtils.join(delta, ",")
               + " are in your local state, but not in the cluster, please investigate!";
       LOGGER.error(errorMessage);
-      throw new IOException(errorMessage);
+      throw new RemoteValidationException(errorMessage);
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/TopicManager.java
+++ b/src/main/java/com/purbon/kafka/topology/TopicManager.java
@@ -138,15 +138,15 @@ public class TopicManager implements ExecutionPlanUpdater {
   private void detectDivergencesInTheRemoteCluster(ExecutionPlan plan) throws IOException {
     var remoteTopics = adminClient.listApplicationTopics();
     var delta =
-            plan.getTopics().stream()
-                    .filter(localTopic -> !remoteTopics.contains(localTopic))
-                    .collect(Collectors.toList());
+        plan.getTopics().stream()
+            .filter(localTopic -> !remoteTopics.contains(localTopic))
+            .collect(Collectors.toList());
 
     if (delta.size() > 0) {
       String errorMessage =
-              "Your remote state has changed since the last execution, this topics: "
-                      + StringUtils.join(delta, ",")
-                      + " are in your local state, but not in the cluster, please investigate!";
+          "Your remote state has changed since the last execution, this topics: "
+              + StringUtils.join(delta, ",")
+              + " are in your local state, but not in the cluster, please investigate!";
       LOGGER.error(errorMessage);
       throw new IOException(errorMessage);
     }

--- a/src/main/java/com/purbon/kafka/topology/exceptions/RemoteValidationException.java
+++ b/src/main/java/com/purbon/kafka/topology/exceptions/RemoteValidationException.java
@@ -1,0 +1,14 @@
+package com.purbon.kafka.topology.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Exception raised when a remote validation error has happened. For example, when there are
+ * discrepancies between local state and the remote state (someone delete a topic outside of
+ * JulieOps)
+ */
+public class RemoteValidationException extends IOException {
+  public RemoteValidationException(String msg) {
+    super(msg);
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -517,6 +517,8 @@ public class AccessControlManagerTest {
 
     Mockito.reset(aclsProvider);
     plan = ExecutionPlan.init(backendController, mockPrintStream);
+    doReturn(mapBindings(plan)).when(aclsProvider).listAcls();
+
     accessControlManager.updatePlan(builder.buildTopology(), plan);
     plan.run();
 
@@ -544,6 +546,8 @@ public class AccessControlManagerTest {
 
     Mockito.reset(aclsProvider);
     plan = ExecutionPlan.init(backendController, mockPrintStream);
+    doReturn(mapBindings(plan)).when(aclsProvider).listAcls();
+
     Topology topology = builder.buildTopology();
     accessControlManager.updatePlan(topology, plan);
     plan.run();
@@ -553,6 +557,15 @@ public class AccessControlManagerTest {
             singletonList(new Consumer("User:app2")), builder.getTopic("topicA").toString());
 
     verify(aclsProvider, times(1)).clearBindings(new HashSet<>(bindingsToDelete));
+  }
+
+  private HashMap<String, List<TopologyAclBinding>> mapBindings(ExecutionPlan plan) {
+    var allBindings = new HashMap<String, List<TopologyAclBinding>>();
+    for (var binding : plan.getBindings()) {
+      allBindings.computeIfAbsent(binding.getResourceName(), k -> new ArrayList<>());
+      allBindings.get(binding.getResourceName()).add(binding);
+    }
+    return allBindings;
   }
 
   private List<TopologyAclBinding> returnAclsForConsumers(List<Consumer> consumers, String topic) {

--- a/src/test/java/com/purbon/kafka/topology/ArtefactManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ArtefactManagerTest.java
@@ -7,7 +7,6 @@ import com.purbon.kafka.topology.model.Artefact;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.artefact.KafkaConnectArtefact;
 import com.purbon.kafka.topology.utils.TestUtils;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;

--- a/src/test/java/com/purbon/kafka/topology/ArtefactManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ArtefactManagerTest.java
@@ -7,6 +7,8 @@ import com.purbon.kafka.topology.model.Artefact;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.artefact.KafkaConnectArtefact;
 import com.purbon.kafka.topology.utils.TestUtils;
+
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,7 +39,12 @@ public class ArtefactManagerTest {
     }
 
     @Override
-    Collection<? extends Artefact> loadActualClusterStateIfAvailable(ExecutionPlan plan) {
+    protected Collection<? extends Artefact> getLocalState(ExecutionPlan plan) {
+      return null;
+    }
+
+    @Override
+    protected Collection<? extends Artefact> getClustersState() throws IOException {
       return new ArrayList<>();
     }
 

--- a/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
@@ -116,6 +116,8 @@ public class TopicManagerTest {
     project.addTopic(topicB);
 
     doReturn(new Config(Collections.emptyList())).when(adminClient).getActualTopicConfig(any());
+    var listOfTopics = new HashSet<>(Arrays.asList(topicA.toString(), topicB.toString()));
+    doReturn(listOfTopics).when(adminClient).listApplicationTopics();
     topicManager.updatePlan(topology, plan);
     plan.run();
 

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import com.purbon.kafka.topology.BackendController;
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.ExecutionPlan;
+import com.purbon.kafka.topology.TestTopologyBuilder;
 import com.purbon.kafka.topology.TopicManager;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.integration.containerutils.ContainerFactory;
@@ -120,6 +121,24 @@ public class TopicManagerIT {
     plan.run();
 
     verifyTopics(Arrays.asList(topicA.toString(), topicB.toString()));
+  }
+
+  @Test(expected = IOException.class)
+  public void topicManagerShouldDetectDeletedTopicsBetweenRuns() throws IOException {
+
+    TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
+
+    Topic topic1 = new Topic("topic1");
+    Topic topic2 = new Topic("topic2");
+
+    var topology =
+        TestTopologyBuilder.createProject().addTopic(topic1).addTopic(topic2).buildTopology();
+
+    topicManager.updatePlan(topology, plan);
+    plan.run();
+
+    adminClient.deleteTopics(Collections.singletonList("ctx.project.topic1"));
+    topicManager.updatePlan(topology, plan);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -11,6 +11,7 @@ import com.purbon.kafka.topology.ExecutionPlan;
 import com.purbon.kafka.topology.TestTopologyBuilder;
 import com.purbon.kafka.topology.TopicManager;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.exceptions.RemoteValidationException;
 import com.purbon.kafka.topology.integration.containerutils.ContainerFactory;
 import com.purbon.kafka.topology.integration.containerutils.ContainerTestUtils;
 import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextKafkaContainer;
@@ -123,7 +124,7 @@ public class TopicManagerIT {
     verifyTopics(Arrays.asList(topicA.toString(), topicB.toString()));
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = RemoteValidationException.class)
   public void topicManagerShouldDetectDeletedTopicsBetweenRuns() throws IOException {
 
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduced a new feature to detect changes between the local state and the remote cluster status. For this first version, JulieOps is going to raise an exception and 🤯  until the divergence is fixed either by updating the local state or fixing the remote cluster. *Note*, in future versions this behaviour will be expected with more granular support.

Managers supported:

- [x] Topics
- [x] Access Control
- [x] Kafka Connect
- [x] ksqlDB

**Note**: Changing resources outside the scope of JulieOps it is not a good practice, but this PR will help teams detect such cases in case they happen.