### PR TITLE
Add validators backwards compatibility

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/TopologyValidator.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyValidator.java
@@ -88,8 +88,15 @@ public class TopologyValidator {
                           validationClass));
                 }
 
-                Constructor<?> constructor = clazz.getConstructor(Configuration.class);
-                Object instance = constructor.newInstance(config);
+                Object instance;
+                try {
+                  Constructor<?> configurationConstructor = clazz.getConstructor(Configuration.class);
+                  instance = configurationConstructor.newInstance(config);
+                } catch (NoSuchMethodException e) {
+                  /* Support pre 4.1.1 validators with no-arg constructors. */
+                  Constructor<?> noArgConstructor = clazz.getConstructor();
+                  instance = noArgConstructor.newInstance();
+                }
                 if (instance instanceof TopologyValidation) {
                   return (TopologyValidation) instance;
                 } else if (instance instanceof TopicValidation) {

--- a/src/main/java/com/purbon/kafka/topology/validation/topic/ConfigurationKeyValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topic/ConfigurationKeyValidation.java
@@ -1,15 +1,11 @@
 package com.purbon.kafka.topology.validation.topic;
 
-import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.validation.TopicValidation;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,13 +13,9 @@ import org.apache.logging.log4j.Logger;
 /**
  * This validation checks that all topic configs are valid ones according to the TopicConfig class.
  */
-@NoArgsConstructor
-@RequiredArgsConstructor
 public class ConfigurationKeyValidation implements TopicValidation {
 
   private static final Logger LOGGER = LogManager.getLogger(ConfigurationKeyValidation.class);
-
-  @NonNull private Configuration config;
 
   @Override
   public void valid(Topic topic) throws ValidationException {

--- a/src/main/java/com/purbon/kafka/topology/validation/topic/PartitionNumberValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topic/PartitionNumberValidation.java
@@ -1,18 +1,10 @@
 package com.purbon.kafka.topology.validation.topic;
 
-import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.validation.TopicValidation;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-@NoArgsConstructor
-@RequiredArgsConstructor
 public class PartitionNumberValidation implements TopicValidation {
-
-  @NonNull private Configuration config;
 
   @Override
   public void valid(Topic topic) throws ValidationException {

--- a/src/main/java/com/purbon/kafka/topology/validation/topic/ReplicationFactorValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topic/ReplicationFactorValidation.java
@@ -1,18 +1,10 @@
 package com.purbon.kafka.topology.validation.topic;
 
-import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.validation.TopicValidation;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-@NoArgsConstructor
-@RequiredArgsConstructor
 public class ReplicationFactorValidation implements TopicValidation {
-
-  @NonNull private Configuration config;
 
   @Override
   public void valid(Topic topic) throws ValidationException {

--- a/src/main/java/com/purbon/kafka/topology/validation/topology/CamelCaseNameFormatValidation.java
+++ b/src/main/java/com/purbon/kafka/topology/validation/topology/CamelCaseNameFormatValidation.java
@@ -1,21 +1,14 @@
 package com.purbon.kafka.topology.validation.topology;
 
-import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.validation.TopologyValidation;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-@NoArgsConstructor
-@RequiredArgsConstructor
 public class CamelCaseNameFormatValidation implements TopologyValidation {
 
   private String camelCasePattern = "([a-z]+[A-Z]+\\w+)+";
-  @NonNull private Configuration config;
 
   @Override
   public void valid(Topology topology) throws ValidationException {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x ] The commit messages are descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Revert backwards compatibility break introduced in https://github.com/kafka-ops/julie/pull/443

* **What is the current behavior?** (You can also link to an open issue here)

Validators with just no-arg constructors fail to load.

* **What is the new behavior (if this is a feature change)?**

Validators with just no-arg constructors will load again, if no Configuration constructor is found.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Hopefully not.

* **Other information**:


