### PR TITLE
Several to use RBAC with new CP version

### DIFF
--- a/docker/rbac-sasl/create-basic-roles.sh
+++ b/docker/rbac-sasl/create-basic-roles.sh
@@ -11,7 +11,7 @@ if [ -z "$KAFKA_CLUSTER_ID" ]; then
 fi
 
 ## Login into MDS
-XX_CONFLUENT_USERNAME=professor XX_CONFLUENT_PASSWORD=professor confluent login --url http://localhost:8090
+confluent login --url http://localhost:8090
 
 SUPER_USER=professor
 SUPER_USER_PASSWORD=professor
@@ -30,18 +30,18 @@ C3=c3-cluster
 ################################### SETUP SUPERUSER ###################################
 echo "Creating Super User role bindings"
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL  \
     --role SystemAdmin \
     --kafka-cluster-id $KAFKA_CLUSTER_ID
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL \
     --role SystemAdmin \
     --kafka-cluster-id $KAFKA_CLUSTER_ID \
     --schema-registry-cluster-id $SR
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL \
     --role SystemAdmin \
     --kafka-cluster-id $KAFKA_CLUSTER_ID \

--- a/docker/rbac-sasl/docker-compose.yml
+++ b/docker/rbac-sasl/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     privileged: true
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -31,7 +31,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:5.5.1
+    image: confluentinc/cp-server:7.0.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -159,7 +159,7 @@ services:
       # CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.1
+    image: confluentinc/cp-schema-registry:7.0.1
     hostname: schema-registry
     container_name: schema-registry
     ports:
@@ -199,7 +199,7 @@ services:
       SCHEMA_REGISTRY_PUBLIC_KEY_PATH: /tmp/conf/public.pem
 
   connect:
-    image: confluentinc/cp-server-connect:5.5.1
+    image: confluentinc/cp-server-connect:7.0.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -292,7 +292,7 @@ services:
                                                                           metadataServerUrls="http://broker:8090";
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.5.1
+    image: confluentinc/cp-enterprise-control-center:7.0.1
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -417,6 +417,10 @@ public class Configuration {
     return config.getString(MDS_SERVER);
   }
 
+  public List<String> getValidClusterIds() {
+    return config.getStringList(MDS_VALID_CLUSTER_IDS_CONFIG);
+  }
+
   public String getKafkaClusterId() {
     return config.getString(MDS_KAFKA_CLUSTER_ID_CONFIG);
   }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -120,7 +120,7 @@ public class Configuration {
 
     if (hasSchemaRegistry) {
       raiseIfNull(MDS_SR_CLUSTER_ID_CONFIG);
-    } else if (hasKafkaConnect && config.getString(MDS_KC_CLUSTER_ID_CONFIG) == null) {
+    } else if (hasKafkaConnect && getString(MDS_KC_CLUSTER_ID_CONFIG) == null) {
       raiseIfNull(MDS_KC_CLUSTER_ID_CONFIG);
     }
   }
@@ -155,7 +155,7 @@ public class Configuration {
   private void validateBrokersConfig() throws ConfigurationException {
     boolean existServersAsConfig;
     try {
-      config.getString(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
+      getString(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
       existServersAsConfig = true;
     } catch (Exception ex) {
       existServersAsConfig = false;
@@ -177,7 +177,7 @@ public class Configuration {
   }
 
   private void raiseIfDefault(String key, String _default) throws ConfigurationException {
-    if (config.getString(key).equals(_default)) {
+    if (getString(key).equals(_default)) {
       throw new ConfigurationException(
           "Configuration key " + key + " should not have the default value " + _default);
     }
@@ -186,7 +186,7 @@ public class Configuration {
   private void raiseIfNull(String... keys) throws ConfigurationException {
     try {
       for (String key : keys) {
-        config.getString(key);
+        getString(key);
       }
     } catch (Exception ex) {
       throw new ConfigurationException(ex.getMessage());
@@ -194,7 +194,7 @@ public class Configuration {
   }
 
   public String getProperty(String key) {
-    return config.getString(key);
+    return getString(key);
   }
 
   public List<String> getKafkaInternalTopicPrefixes() {
@@ -250,47 +250,47 @@ public class Configuration {
   }
 
   public String getConfluentSchemaRegistryUrl() {
-    return config.getString(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG);
+    return getString(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG);
   }
 
   public String getConfluentMonitoringTopic() {
-    return config.getString(CONFLUENT_MONITORING_TOPIC_CONFIG);
+    return getString(CONFLUENT_MONITORING_TOPIC_CONFIG);
   }
 
   public String getConfluentCommandTopic() {
-    return config.getString(CONFLUENT_COMMAND_TOPIC_CONFIG);
+    return getString(CONFLUENT_COMMAND_TOPIC_CONFIG);
   }
 
   public String getConfluentMetricsTopic() {
-    return config.getString(CONFLUENT_METRICS_TOPIC_CONFIG);
+    return getString(CONFLUENT_METRICS_TOPIC_CONFIG);
   }
 
   public String getAccessControlClassName() {
-    return config.getString(ACCESS_CONTROL_IMPLEMENTATION_CLASS);
+    return getString(ACCESS_CONTROL_IMPLEMENTATION_CLASS);
   }
 
   public String getStateProcessorImplementationClassName() {
-    return config.getString(STATE_PROCESSOR_IMPLEMENTATION_CLASS);
+    return getString(STATE_PROCESSOR_IMPLEMENTATION_CLASS);
   }
 
   public String getTopicPrefixFormat() {
-    return config.getString(TOPIC_PREFIX_FORMAT_CONFIG);
+    return getString(TOPIC_PREFIX_FORMAT_CONFIG);
   }
 
   public String getDlqTopicPrefixFormat() {
-    return config.getString(DLQ_TOPIC_PREFIX_FORMAT_CONFIG);
+    return getString(DLQ_TOPIC_PREFIX_FORMAT_CONFIG);
   }
 
   public String getDlqTopicLabel() {
-    return config.getString(DLQ_TOPIC_LABEL_CONFIG);
+    return getString(DLQ_TOPIC_LABEL_CONFIG);
   }
 
   public String getProjectPrefixFormat() {
-    return config.getString(PROJECT_PREFIX_FORMAT_CONFIG);
+    return getString(PROJECT_PREFIX_FORMAT_CONFIG);
   }
 
   public String getTopicPrefixSeparator() {
-    return config.getString(TOPIC_PREFIX_SEPARATOR_CONFIG);
+    return getString(TOPIC_PREFIX_SEPARATOR_CONFIG);
   }
 
   public Boolean shouldOptimizeAcls() {
@@ -298,7 +298,7 @@ public class Configuration {
   }
 
   public String getConfluentCloudEnv() {
-    return config.getString(CCLOUD_ENV_CONFIG);
+    return getString(CCLOUD_ENV_CONFIG);
   }
 
   public boolean enabledExperimental() {
@@ -312,9 +312,9 @@ public class Configuration {
   public Optional<String> getInternalPrincipalOptional() {
     String internalPrincipal = null;
     if (hasProperty(JULIE_INTERNAL_PRINCIPAL)) {
-      internalPrincipal = config.getString(JULIE_INTERNAL_PRINCIPAL);
+      internalPrincipal = getString(JULIE_INTERNAL_PRINCIPAL);
     } else if (hasProperty(TOPOLOGY_BUILDER_INTERNAL_PRINCIPAL)) {
-      internalPrincipal = config.getString(TOPOLOGY_BUILDER_INTERNAL_PRINCIPAL);
+      internalPrincipal = getString(TOPOLOGY_BUILDER_INTERNAL_PRINCIPAL);
     }
     return Optional.ofNullable(internalPrincipal);
   }
@@ -382,11 +382,11 @@ public class Configuration {
   }
 
   public String getRedisBucket() {
-    return config.getString(REDIS_BUCKET_CONFIG);
+    return getString(REDIS_BUCKET_CONFIG);
   }
 
   public String getRedisHost() {
-    return config.getString(REDIS_HOST_CONFIG);
+    return getString(REDIS_HOST_CONFIG);
   }
 
   public int getRedisPort() {
@@ -394,27 +394,27 @@ public class Configuration {
   }
 
   public String getS3Bucket() {
-    return config.getString(JULIE_S3_BUCKET);
+    return getString(JULIE_S3_BUCKET);
   }
 
   public String getS3Endpoint() {
-    return config.getString(JULIE_S3_ENDPOINT);
+    return getString(JULIE_S3_ENDPOINT);
   }
 
   public String getS3Region() {
-    return config.getString(JULIE_S3_REGION);
+    return getString(JULIE_S3_REGION);
   }
 
   public String getGCPProjectId() {
-    return config.getString(JULIE_GCP_PROJECT_ID);
+    return getString(JULIE_GCP_PROJECT_ID);
   }
 
   public String getGCPBucket() {
-    return config.getString(JULIE_GCP_BUCKET);
+    return getString(JULIE_GCP_BUCKET);
   }
 
   public String getMdsServer() {
-    return config.getString(MDS_SERVER);
+    return getString(MDS_SERVER);
   }
 
   public List<String> getValidClusterIds() {
@@ -422,24 +422,24 @@ public class Configuration {
   }
 
   public String getKafkaClusterId() {
-    return config.getString(MDS_KAFKA_CLUSTER_ID_CONFIG);
+    return getString(MDS_KAFKA_CLUSTER_ID_CONFIG);
   }
 
   public String getSchemaRegistryClusterId() {
-    return config.getString(MDS_SR_CLUSTER_ID_CONFIG);
+    return getString(MDS_SR_CLUSTER_ID_CONFIG);
   }
 
   public String getKafkaConnectClusterId() {
-    return config.getString(MDS_KC_CLUSTER_ID_CONFIG);
+    return getString(MDS_KC_CLUSTER_ID_CONFIG);
   }
 
   public String getKsqlDBClusterID() {
-    return config.getString(MDS_KSQLDB_CLUSTER_ID_CONFIG);
+    return getString(MDS_KSQLDB_CLUSTER_ID_CONFIG);
   }
 
   public Optional<String> getSslTrustStoreLocation() {
     try {
-      return Optional.of(config.getString(SSL_TRUSTSTORE_LOCATION));
+      return Optional.of(getString(SSL_TRUSTSTORE_LOCATION));
     } catch (ConfigException.Missing missingEx) {
       return Optional.empty();
     }
@@ -447,7 +447,7 @@ public class Configuration {
 
   public Optional<String> getSslTrustStorePassword() {
     try {
-      return Optional.of(config.getString(SSL_TRUSTSTORE_PASSWORD));
+      return Optional.of(getString(SSL_TRUSTSTORE_PASSWORD));
     } catch (ConfigException.Missing missingEx) {
       return Optional.empty();
     }
@@ -455,7 +455,7 @@ public class Configuration {
 
   public Optional<String> getSslKeyStoreLocation() {
     try {
-      return Optional.of(config.getString(SSL_KEYSTORE_LOCATION));
+      return Optional.of(getString(SSL_KEYSTORE_LOCATION));
     } catch (ConfigException.Missing missingEx) {
       return Optional.empty();
     }
@@ -463,7 +463,7 @@ public class Configuration {
 
   public Optional<String> getSslKeyStorePassword() {
     try {
-      return Optional.of(config.getString(SSL_KEYSTORE_PASSWORD));
+      return Optional.of(getString(SSL_KEYSTORE_PASSWORD));
     } catch (ConfigException.Missing missingEx) {
       return Optional.empty();
     }
@@ -471,7 +471,7 @@ public class Configuration {
 
   public Optional<String> getSslKeyPassword() {
     try {
-      return Optional.of(config.getString(SSL_KEY_PASSWORD));
+      return Optional.of(getString(SSL_KEY_PASSWORD));
     } catch (ConfigException.Missing missingEx) {
       return Optional.empty();
     }
@@ -537,7 +537,7 @@ public class Configuration {
 
   private String getPropertyOrNull(String key, String defaultKey) {
     try {
-      return config.getString(key);
+      return getString(key);
     } catch (ConfigException.Missing e) {
       if (!defaultKey.isBlank()) {
         return getPropertyOrNull(defaultKey, "");
@@ -557,7 +557,7 @@ public class Configuration {
   public JulieRoles getJulieRoles() throws IOException {
     JulieRolesSerdes serdes = new JulieRolesSerdes();
     try {
-      String path = config.getString(JULIE_ROLES);
+      String path = getString(JULIE_ROLES);
       return serdes.deserialise(Paths.get(path).toFile());
     } catch (ConfigException.Missing | ConfigException.WrongType ex) {
       LOGGER.debug(ex);
@@ -585,7 +585,7 @@ public class Configuration {
   }
 
   public String getJulieKafkaConfigTopic() {
-    return config.getString(JULIE_KAFKA_CONFIG_TOPIC);
+    return getString(JULIE_KAFKA_CONFIG_TOPIC);
   }
 
   public String getJulieInstanceId() {
@@ -593,7 +593,7 @@ public class Configuration {
       return julieInstanceId;
     }
     try {
-      julieInstanceId = config.getString(JULIE_INSTANCE_ID);
+      julieInstanceId = getString(JULIE_INSTANCE_ID);
     } catch (ConfigException.Missing | ConfigException.WrongType errorType) {
       generateRandomJulieInstanceId();
     }
@@ -619,7 +619,7 @@ public class Configuration {
   }
 
   public String getKafkaBackendConsumerGroupId() {
-    return config.getString(JULIE_KAFKA_CONSUMER_GROUP_ID);
+    return getString(JULIE_KAFKA_CONSUMER_GROUP_ID);
   }
 
   public Integer getKafkaBackendConsumerRetries() {
@@ -627,23 +627,23 @@ public class Configuration {
   }
 
   public BasicAuth getConfluentCloudClusterAuth() {
-    var user = config.getString(CCLOUD_CLUSTER_API_KEY);
-    var pass = config.getString(CCLOUD_CLUSTER_API_SECRET);
+    var user = getString(CCLOUD_CLUSTER_API_KEY);
+    var pass = getString(CCLOUD_CLUSTER_API_SECRET);
     return new BasicAuth(user, pass);
   }
 
   public BasicAuth getConfluentCloudCloudApiAuth() {
-    var user = config.getString(CCLOUD_CLOUD_API_KEY);
-    var pass = config.getString(CCLOUD_CLOUD_API_SECRET);
+    var user = getString(CCLOUD_CLOUD_API_KEY);
+    var pass = getString(CCLOUD_CLOUD_API_SECRET);
     return new BasicAuth(user, pass);
   }
 
   public String getConfluentCloudClusterId() {
-    return config.getString(CCLOUD_KAFKA_CLUSTER_ID_CONFIG);
+    return getString(CCLOUD_KAFKA_CLUSTER_ID_CONFIG);
   }
 
   public String getConfluentCloudClusterUrl() {
-    return config.getString(CCLOUD_CLUSTER_URL);
+    return getString(CCLOUD_CLUSTER_URL);
   }
 
   public Boolean isConfluentCloudServiceAccountTranslationEnabled() {
@@ -655,14 +655,18 @@ public class Configuration {
   }
 
   public String getKafkaAuditTopic() {
-    return config.getString(AUDIT_APPENDER_KAFKA_TOPIC);
+    return getString(AUDIT_APPENDER_KAFKA_TOPIC);
   }
 
   public String getJulieAuditAppenderClass() {
-    return config.getString(JULIE_AUDIT_APPENDER_CLASS);
+    return getString(JULIE_AUDIT_APPENDER_CLASS);
   }
 
   public Boolean isJulieAuditEnabled() {
     return config.getBoolean(JULIE_AUDIT_ENABLED);
+  }
+
+  private String getString(String path) {
+    return config.getString(path).strip().trim();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -47,6 +47,9 @@ public class Constants {
   static final String MDS_KC_CLUSTER_ID_CONFIG = "topology.builder.mds.kafka.connect.cluster.id";
   static final String MDS_KSQLDB_CLUSTER_ID_CONFIG = "topology.builder.mds.ksqldb.cluster.id";
 
+  public static final String MDS_VALID_CLUSTER_IDS_CONFIG =
+      "topology.builder.mds.valid.cluster.ids";
+
   public static final String CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   static final String CONFLUENT_MONITORING_TOPIC_CONFIG = "confluent.monitoring.topic";
   static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";

--- a/src/main/java/com/purbon/kafka/topology/api/mds/ClusterIDs.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/ClusterIDs.java
@@ -1,7 +1,13 @@
 package com.purbon.kafka.topology.api.mds;
 
+import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.exceptions.ValidationException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import lombok.SneakyThrows;
 
 public class ClusterIDs implements Cloneable {
 
@@ -9,6 +15,7 @@ public class ClusterIDs implements Cloneable {
   private String schemaRegistryClusterID;
   private String connectClusterID;
   private String ksqlClusterID;
+  private List<String> validClusterIds;
 
   public static String KAFKA_CLUSTER_ID_LABEL = "kafka-cluster";
   public static String SCHEMA_REGISTRY_CLUSTER_ID_LABEL = "schema-registry-cluster";
@@ -18,10 +25,16 @@ public class ClusterIDs implements Cloneable {
   private Map<String, String> clusterIds;
 
   public ClusterIDs() {
+    this(Optional.empty());
+  }
+
+  public ClusterIDs(Optional<Configuration> configOptional) {
     this.connectClusterID = "";
     this.kafkaClusterID = "";
     this.schemaRegistryClusterID = "";
     this.clusterIds = new HashMap<>();
+    this.validClusterIds = new ArrayList<>();
+    configOptional.ifPresent(config -> validClusterIds = config.getValidClusterIds());
   }
 
   public Map<String, Map<String, String>> getKafkaClusterIds() {
@@ -64,16 +77,31 @@ public class ClusterIDs implements Cloneable {
     return clusters;
   }
 
-  public void setKafkaClusterId(String kafkaClusterID) {
-    this.kafkaClusterID = kafkaClusterID;
+  @SneakyThrows
+  public void setKafkaClusterId(String clusterId) {
+    if (!isItValidId(clusterId)) {
+      throw new ValidationException(
+          "Kafka clusterId: " + clusterId + " is it not valid. Check your config!");
+    }
+    this.kafkaClusterID = clusterId;
   }
 
-  public void setSchemaRegistryClusterID(String schemaRegistryClusterID) {
-    this.schemaRegistryClusterID = schemaRegistryClusterID;
+  @SneakyThrows
+  public void setSchemaRegistryClusterID(String clusterId) {
+    if (!isItValidId(clusterId)) {
+      throw new ValidationException(
+          "Schema Registry clusterId: " + clusterId + " is it not valid. Check your config!");
+    }
+    this.schemaRegistryClusterID = clusterId;
   }
 
-  public void setConnectClusterID(String connectClusterID) {
-    this.connectClusterID = connectClusterID;
+  @SneakyThrows
+  public void setConnectClusterID(String clusterId) {
+    if (!isItValidId(clusterId)) {
+      throw new ValidationException(
+          "Kafka Connect clusterId: " + clusterId + " is it not valid. Check your config!");
+    }
+    this.connectClusterID = clusterId;
   }
 
   public ClusterIDs clone() {
@@ -85,7 +113,16 @@ public class ClusterIDs implements Cloneable {
     return clusterIDs;
   }
 
+  @SneakyThrows
   public void setKsqlClusterID(String clusterId) {
+    if (!isItValidId(clusterId)) {
+      throw new ValidationException(
+          "ksqlClusterId: " + clusterId + " is it not valid. Check your config!");
+    }
     this.ksqlClusterID = clusterId;
+  }
+
+  private boolean isItValidId(String clusterId) {
+    return validClusterIds.isEmpty() || validClusterIds.contains(clusterId);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
@@ -33,7 +33,7 @@ public class MDSApiClient extends JulieHttpClient {
 
   public MDSApiClient(String mdsServer, Optional<Configuration> configOptional) {
     super(mdsServer, configOptional);
-    this.clusterIDs = new ClusterIDs();
+    this.clusterIDs = new ClusterIDs(configOptional);
   }
 
   public AuthenticationCredentials getCredentials() {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,7 @@ topology {
     access.control.class = "com.purbon.kafka.topology.roles.SimpleAclsProvider"
     mds {
         server = "http://localhost:8090"
+        valid.cluster.ids = []
     }
     state {
       processor.class = "com.purbon.kafka.topology.backend.FileBackend"

--- a/src/test/java/com/purbon/kafka/topology/ClusterIDsTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ClusterIDsTest.java
@@ -1,0 +1,61 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.api.mds.ClusterIDs;
+import com.purbon.kafka.topology.exceptions.ValidationException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
+import static com.purbon.kafka.topology.Constants.MDS_VALID_CLUSTER_IDS_CONFIG;
+
+public class ClusterIDsTest {
+
+    private Map<String, String> cliOps;
+    private Properties props;
+
+    @Before
+    public void before() {
+        cliOps = new HashMap<>();
+        cliOps.put(BROKERS_OPTION, "");
+        props = new Properties();
+    }
+
+    @After
+    public void after() {
+
+    }
+
+    @Test(expected = ValidationException.class)
+    public void shouldRaiseAnExceptionIfAnInvalidClusterIdIsUsed() {
+        props.put(MDS_VALID_CLUSTER_IDS_CONFIG+".0", "kafka-cluster");
+        Configuration config = new Configuration(cliOps, props);
+
+        ClusterIDs ids = new ClusterIDs(Optional.of(config));
+        ids.setKafkaClusterId("foo");
+    }
+
+    @Test
+    public void shouldAcceptAValidID() {
+        props.put(MDS_VALID_CLUSTER_IDS_CONFIG+".0", "kafka-cluster");
+        Configuration config = new Configuration(cliOps, props);
+
+        ClusterIDs ids = new ClusterIDs(Optional.of(config));
+        ids.setKafkaClusterId("kafka-cluster");
+    }
+
+    @Test
+    public void shouldAnyIdIfTheListIsEmpty() {
+        Configuration config = new Configuration(cliOps, props);
+
+        ClusterIDs ids = new ClusterIDs(Optional.of(config));
+        ids.setKafkaClusterId("kafka-cluster");
+        ids.setKafkaClusterId("kafka-cluster       ");
+        ids.setKafkaClusterId("");
+    }
+}


### PR DESCRIPTION
-     add a method to simple sanitize a string that could contain empty values 
-     upgrade rback-sasl to use 7.0.1
-     add a pre-flight check for valid clusterIds in your platform