### PR TITLE
Add feature flag to make the remote state verification backwards compatible again

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -83,7 +83,13 @@ public class AccessControlManager implements ExecutionPlanUpdater {
             .filter(this::isNotInternalAcl)
             .collect(Collectors.toSet());
 
-    if (!config.fetchStateFromTheCluster()) {
+    if (!config.shouldVerifyRemoteState()) {
+      LOGGER.warn(
+          "Remote state verification disabled, this is not a good practice, be aware"
+              + "in future versions, this check is going to become mandatory.");
+    }
+
+    if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {
       // should detect if there are divergences between the local cluster state and the current
       // status in the cluster
       detectDivergencesInTheRemoteCluster(plan);

--- a/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
@@ -93,7 +93,13 @@ public abstract class ArtefactManager implements ExecutionPlanUpdater {
       throws IOException {
     var currentState = config.fetchStateFromTheCluster() ? getClustersState() : getLocalState(plan);
 
-    if (!config.fetchStateFromTheCluster()) {
+    if (!config.shouldVerifyRemoteState()) {
+      LOGGER.warn(
+          "Remote state verification disabled, this is not a good practice, be aware"
+              + "in future versions, this check is going to become mandatory.");
+    }
+
+    if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {
       // should detect if there are divergences between the local cluster state and the current
       // status in the cluster
       detectDivergencesInTheRemoteCluster(plan);

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -674,6 +674,10 @@ public class Configuration {
     return config.getBoolean(JULIE_DEBUG_MODE);
   }
 
+  public Boolean shouldVerifyRemoteState() {
+    return config.getBoolean(JULIE_VERIFY_STATE_SYNC);
+  }
+
   private String getString(String path) {
     return config.getString(path).strip().trim();
   }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -167,4 +167,6 @@ public class Constants {
   public static final String JULIE_AUDIT_ENABLED = "julie.audit.enabled";
 
   public static final String JULIE_DEBUG_MODE = "julie.debug.mode";
+
+  public static final String JULIE_VERIFY_STATE_SYNC = "julie.verify.remote.state";
 }

--- a/src/main/java/com/purbon/kafka/topology/TopicManager.java
+++ b/src/main/java/com/purbon/kafka/topology/TopicManager.java
@@ -135,7 +135,13 @@ public class TopicManager implements ExecutionPlanUpdater {
           "Full list of managed topics in the cluster: "
               + StringUtils.join(new ArrayList<>(listOfTopics), ","));
 
-    if (!config.fetchStateFromTheCluster()) {
+    if (!config.shouldVerifyRemoteState()) {
+      LOGGER.warn(
+          "Remote state verification disabled, this is not a good practice, be aware"
+              + "in future versions, this check is going to become mandatory.");
+    }
+
+    if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {
       // verify that the remote state does not contain different topics than the local state
       detectDivergencesInTheRemoteCluster(plan);
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -95,6 +95,10 @@ julie {
     enable.principal.management = false
     enable.principal.management = ${?JULIE_ENABLE_PRINCIPAL_MANAGEMENT}
 
+    verify.remote.state = false
+    verify.remote.state = ${?JULIE_VERIFY_REMOTE_STATE}
+
+
     audit {
        enabled = false
        enabled = ${?JULIE_AUDIT_ENABLED}

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -197,6 +197,18 @@ public class AccessControlManagerIT {
 
   @Test(expected = IOException.class)
   public void shouldDetectChangesInTheRemoteClusterBetweenRuns() throws IOException {
+
+    Properties props = new Properties();
+    props.put(ALLOW_DELETE_BINDINGS, true);
+    props.put(JULIE_VERIFY_STATE_SYNC, true);
+
+    HashMap<String, String> cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+
+    Configuration config = new Configuration(cliOps, props);
+
+    accessControlManager = new AccessControlManager(aclsProvider, bindingsBuilder, config);
+
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
 
     var topology =
@@ -208,10 +220,6 @@ public class AccessControlManagerIT {
 
     accessControlManager.updatePlan(topology, plan);
     plan.run();
-
-    System.out.println("****");
-    adminClient.fetchAclsList().values().forEach(System.out::println);
-    System.out.println("****");
 
     var binding =
         TopologyAclBinding.build(

--- a/src/test/java/com/purbon/kafka/topology/integration/ConnectorManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/ConnectorManagerIT.java
@@ -91,6 +91,7 @@ public class ConnectorManagerIT {
     Properties props = new Properties();
     props.put(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER, "false");
     props.put(ALLOW_DELETE_CONNECT_ARTEFACTS, "true");
+    props.put(JULIE_VERIFY_STATE_SYNC, true);
     props.put(PLATFORM_SERVERS_CONNECT + ".0", "connector0:" + connectContainer.getHttpsUrl());
 
     File file = TestUtils.getResourceFile("/descriptor-connector.yaml");

--- a/src/test/java/com/purbon/kafka/topology/integration/KsqlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/KsqlManagerIT.java
@@ -88,6 +88,7 @@ public class KsqlManagerIT {
     props.put(TOPOLOGY_STATE_FROM_CLUSTER, "false");
     props.put(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER, "false");
     props.put(ALLOW_DELETE_KSQL_ARTEFACTS, "true");
+    props.put(JULIE_VERIFY_STATE_SYNC, true);
     props.put(PLATFORM_SERVER_KSQL_URL, "http://" + client.getServer());
 
     File file = TestUtils.getResourceFile("/descriptor-ksql.yaml");

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -129,6 +129,22 @@ public class TopicManagerIT {
 
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
 
+    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    final SchemaRegistryManager schemaRegistryManager =
+        new SchemaRegistryManager(schemaRegistryClient, System.getProperty("user.dir"));
+
+    Properties props = new Properties();
+    props.put(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER, "false");
+    props.put(ALLOW_DELETE_TOPICS, true);
+    props.put(JULIE_VERIFY_STATE_SYNC, true);
+
+    HashMap<String, String> cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+
+    Configuration config = new Configuration(cliOps, props);
+
+    this.topicManager = new TopicManager(adminClient, schemaRegistryManager, config);
+
     Topic topic1 = new Topic("topic1");
     Topic topic2 = new Topic("topic2");
 


### PR DESCRIPTION
to be removed in future versions and make true by default.