### PR TITLE
Add a config test to validate when people use empty managed prefixes as mistake

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -154,7 +154,6 @@ public class Configuration {
 
     Arrays.asList(TOPIC_MANAGED_PREFIXES, GROUP_MANAGED_PREFIXES, SERVICE_ACCOUNT_MANAGED_PREFIXES)
           .forEach(this::validateManagedPrefixes);
-
   }
 
   private void validateManagedPrefixes(String key) {

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 
 public class Configuration {
 
@@ -149,6 +150,19 @@ public class Configuration {
     if (!getTopicPrefixFormat().startsWith(getProjectPrefixFormat())) {
       throw new ConfigurationException(
           TOPIC_PREFIX_FORMAT_CONFIG + "should start by" + PROJECT_PREFIX_FORMAT_CONFIG);
+    }
+
+    Arrays.asList(TOPIC_MANAGED_PREFIXES, GROUP_MANAGED_PREFIXES, SERVICE_ACCOUNT_MANAGED_PREFIXES)
+          .forEach(this::validateManagedPrefixes);
+
+  }
+
+  private void validateManagedPrefixes(String key) {
+    List<String> managedTopicPrefixes = config.getStringList(key);
+    if (managedTopicPrefixes.contains("")) {
+      throw new ConfigurationException(
+              String.format("The config key %s, contains empty strings, this is not possible, please review", key)
+      );
     }
   }
 

--- a/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
@@ -303,4 +303,36 @@ public class ConfigurationTest {
     assertThat(props).containsEntry(AUDIT_APPENDER_KAFKA_TOPIC, "log");
     assertThat(props).containsEntry(JULIE_AUDIT_APPENDER_CLASS, "foo.class");
   }
+
+  @Test
+  public void nonEmptyTopicManagedPrefixConfigsShouldValidateSuccessfully() throws ConfigurationException {
+    var topology = TestTopologyBuilder.createProject().buildTopology();
+    props.put(TOPIC_MANAGED_PREFIXES + ".0", "foo");
+    Configuration config = new Configuration(cliOps, props);
+    config.validateWith(topology);
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void emptyTopicManagedPrefixConfigsShouldRaiseAnError() throws ConfigurationException {
+    var topology = TestTopologyBuilder.createProject().buildTopology();
+    props.put(TOPIC_MANAGED_PREFIXES + ".0", "");
+    Configuration config = new Configuration(cliOps, props);
+    config.validateWith(topology);
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void emptyGroupManagedPrefixConfigsShouldRaiseAnError() throws ConfigurationException {
+    var topology = TestTopologyBuilder.createProject().buildTopology();
+    props.put(GROUP_MANAGED_PREFIXES + ".0", "");
+    Configuration config = new Configuration(cliOps, props);
+    config.validateWith(topology);
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void emptySaManagedPrefixConfigsShouldRaiseAnError() throws ConfigurationException {
+    var topology = TestTopologyBuilder.createProject().buildTopology();
+    props.put(SERVICE_ACCOUNT_MANAGED_PREFIXES + ".0", "");
+    Configuration config = new Configuration(cliOps, props);
+    config.validateWith(topology);
+  }
 }


### PR DESCRIPTION
close #514 