### PR TITLE
Add Subject prefix filtering support

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -285,6 +285,22 @@ An example configuration might look like this:
 If this prefix list is used, only groups that match the prefix will be ever processed, if wildcard it will be managed if the service account is managed by Julie Ops, anything else will be ignored.
 This is useful in a shared cluster, to avoid Julie Ops removing/accidentally managing group acls by other teams with seperate pipelines.
 
+Control allowed Subject to be managed by Julie Ops
+-----------
+
+This property is used to control which Subject prefixes are allowed to be managed by Julie Ops, this variable contains a list of allowed prefixes.
+
+**Property**: *topology.subject.managed.prefixes*
+**Default value**: "[]"
+
+An example configuration might look like this:
+::
+    topology.subject.managed.prefixes.0=NameSpaceA
+    topology.subject.managed.prefixes.1=NameSpaceB
+
+If this prefix list is used, only subjects that match the prefix will be ever processed, if wildcard it will be managed if the service account is managed by Julie Ops, anything else will be ignored.
+This is useful in a shared cluster, to avoid Julie Ops removing/accidentally managing subject acls by other teams with seperate pipelines.
+
 HTTPs configuration (TLS)
 -----------
 

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -153,9 +153,10 @@ public class AccessControlManager implements ExecutionPlanUpdater {
         connector
             .getConnectors()
             .ifPresent(
-                (list) -> aclBindingsResults.add(
-                    new ConnectorAuthorizationAclBindingsBuilder(bindingsBuilder, connector)
-                        .getAclBindings()));
+                (list) ->
+                    aclBindingsResults.add(
+                        new ConnectorAuthorizationAclBindingsBuilder(bindingsBuilder, connector)
+                            .getAclBindings()));
       }
 
       for (Schemas schemaAuthorization : project.getSchemas()) {
@@ -306,7 +307,6 @@ public class AccessControlManager implements ExecutionPlanUpdater {
     }
     return updateActions;
   }
-
 
   // Sync platform relevant Access Control List.
   private List<AclBindingsResult> buildPlatformLevelActions(final Topology topology) {

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 
 public class Configuration {
 
@@ -153,15 +152,16 @@ public class Configuration {
     }
 
     Arrays.asList(TOPIC_MANAGED_PREFIXES, GROUP_MANAGED_PREFIXES, SERVICE_ACCOUNT_MANAGED_PREFIXES)
-          .forEach(this::validateManagedPrefixes);
+        .forEach(this::validateManagedPrefixes);
   }
 
   private void validateManagedPrefixes(String key) {
     List<String> managedTopicPrefixes = config.getStringList(key);
     if (managedTopicPrefixes.contains("")) {
       throw new ConfigurationException(
-              String.format("The config key %s, contains empty strings, this is not possible, please review", key)
-      );
+          String.format(
+              "The config key %s, contains empty strings, this is not possible, please review",
+              key));
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -262,6 +262,12 @@ public class Configuration {
         .collect(Collectors.toList());
   }
 
+  public List<String> getSubjectManagedPrefixes() {
+    return config.getStringList(SUBJECT_MANAGED_PREFIXES).stream()
+        .map(String::trim)
+        .collect(Collectors.toList());
+  }
+
   public String getConfluentSchemaRegistryUrl() {
     return getString(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG);
   }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -118,6 +118,8 @@ public class Constants {
 
   public static final String GROUP_MANAGED_PREFIXES = "topology.group.managed.prefixes";
 
+  public static final String SUBJECT_MANAGED_PREFIXES = "topology.subject.managed.prefixes";
+
   public static final String PLATFORM_SERVERS_CONNECT = "platform.servers.connect";
   public static final String PLATFORM_SERVERS_BASIC_AUTH = "platform.servers.basic.auth";
 

--- a/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
@@ -1,95 +1,96 @@
 package com.purbon.kafka.topology.roles;
 
 import com.purbon.kafka.topology.Configuration;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
-
 public class ResourceFilter {
 
-    private static final Logger LOGGER = LogManager.getLogger(ResourceFilter.class);
+  private static final Logger LOGGER = LogManager.getLogger(ResourceFilter.class);
 
-    private final List<String> managedServiceAccountPrefixes;
-    private final List<String> managedTopicPrefixes;
-    private final List<String> managedGroupPrefixes;
-    private final List<String> managedSubjectPrefixes;
+  private final List<String> managedServiceAccountPrefixes;
+  private final List<String> managedTopicPrefixes;
+  private final List<String> managedGroupPrefixes;
+  private final List<String> managedSubjectPrefixes;
 
-    public ResourceFilter(Configuration config) {
-        this.managedServiceAccountPrefixes = config.getServiceAccountManagedPrefixes();
-        this.managedTopicPrefixes = config.getTopicManagedPrefixes();
-        this.managedGroupPrefixes = config.getGroupManagedPrefixes();
-        this.managedSubjectPrefixes = config.getSubjectManagedPrefixes();
+  public ResourceFilter(Configuration config) {
+    this.managedServiceAccountPrefixes = config.getServiceAccountManagedPrefixes();
+    this.managedTopicPrefixes = config.getTopicManagedPrefixes();
+    this.managedGroupPrefixes = config.getGroupManagedPrefixes();
+    this.managedSubjectPrefixes = config.getSubjectManagedPrefixes();
+  }
+
+  public boolean matchesManagedPrefixList(TopologyAclBinding topologyAclBinding) {
+    String resourceName = topologyAclBinding.getResourceName();
+    String principle = topologyAclBinding.getPrincipal();
+    // For global wild cards ACL's we manage only if we manage the service account/principle,
+    // regardless. Filtering by service account will always take precedence if defined
+    if (hasServiceAccountPrefixFilters() || resourceName.equals("*")) {
+      if (resourceName.equals("*")) {
+        return matchesServiceAccountPrefixList(principle);
+      } else {
+        return matchesServiceAccountPrefixList(principle)
+            && matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
+      }
+    } else if (hasTopicNamePrefixFilter()
+        || hasGroupNamePrefixFilter()
+        || hasSubjectNamePrefixFilter()) {
+      return matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
     }
 
-    public boolean matchesManagedPrefixList(TopologyAclBinding topologyAclBinding) {
-        String resourceName = topologyAclBinding.getResourceName();
-        String principle = topologyAclBinding.getPrincipal();
-        // For global wild cards ACL's we manage only if we manage the service account/principle,
-        // regardless. Filtering by service account will always take precedence if defined
-        if (hasServiceAccountPrefixFilters() || resourceName.equals("*")) {
-            if (resourceName.equals("*")) {
-                return matchesServiceAccountPrefixList(principle);
-            } else {
-               return matchesServiceAccountPrefixList(principle)
-                       && matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
-            }
-        } else if (hasTopicNamePrefixFilter() || hasGroupNamePrefixFilter() || hasSubjectNamePrefixFilter()) {
-            return matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
-        }
+    return true; // should include everything if not properly excluded earlier.
+  }
 
-        return true; // should include everything if not properly excluded earlier.
+  private boolean matchesTopicOrSubjectOrGroupPrefix(
+      TopologyAclBinding topologyAclBinding, String resourceName) {
+    if ("TOPIC".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
+      return matchesTopicPrefixList(resourceName);
+    } else if ("SUBJECT".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
+      return matchesSubjectPrefixList(resourceName);
+    } else if ("GROUP".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
+      return matchesGroupPrefixList(resourceName);
+    } else {
+      // Nothing to filter out here
+      return true;
     }
+  }
 
-    private boolean matchesTopicOrSubjectOrGroupPrefix(
-            TopologyAclBinding topologyAclBinding, String resourceName) {
-        if ("TOPIC".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
-            return matchesTopicPrefixList(resourceName);
-        } else if ("SUBJECT".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
-            return matchesSubjectPrefixList(resourceName);
-        } else if ("GROUP".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
-            return matchesGroupPrefixList(resourceName);
-        } else {
-            // Nothing to filter out here
-            return true;
-        }
-    }
+  private boolean matchesTopicPrefixList(String topic) {
+    return matchesPrefix(managedTopicPrefixes, topic, "Topic");
+  }
 
-    private boolean matchesTopicPrefixList(String topic) {
-        return matchesPrefix(managedTopicPrefixes, topic, "Topic");
-    }
+  private boolean matchesGroupPrefixList(String group) {
+    return matchesPrefix(managedGroupPrefixes, group, "Group");
+  }
 
-    private boolean matchesGroupPrefixList(String group) {
-        return matchesPrefix(managedGroupPrefixes, group, "Group");
-    }
+  private boolean matchesSubjectPrefixList(String subject) {
+    return matchesPrefix(managedSubjectPrefixes, subject, "Subject");
+  }
 
-    private boolean matchesSubjectPrefixList(String subject) {
-        return matchesPrefix(managedSubjectPrefixes, subject, "Subject");
-    }
+  private boolean matchesServiceAccountPrefixList(String principal) {
+    return matchesPrefix(managedServiceAccountPrefixes, principal, "Principal");
+  }
 
-    private boolean matchesServiceAccountPrefixList(String principal) {
-        return matchesPrefix(managedServiceAccountPrefixes, principal, "Principal");
-    }
+  private boolean hasServiceAccountPrefixFilters() {
+    return managedServiceAccountPrefixes.size() != 0;
+  }
 
-    private boolean hasServiceAccountPrefixFilters() {
-        return managedServiceAccountPrefixes.size() != 0;
-    }
+  private boolean hasTopicNamePrefixFilter() {
+    return managedTopicPrefixes.size() != 0;
+  }
 
-    private boolean hasTopicNamePrefixFilter() {
-        return managedTopicPrefixes.size() != 0;
-    }
+  private boolean hasGroupNamePrefixFilter() {
+    return managedGroupPrefixes.size() != 0;
+  }
 
-    private boolean hasGroupNamePrefixFilter() {
-        return managedGroupPrefixes.size() != 0;
-    }
+  private boolean hasSubjectNamePrefixFilter() {
+    return managedSubjectPrefixes.size() != 0;
+  }
 
-    private boolean hasSubjectNamePrefixFilter() {
-        return managedSubjectPrefixes.size() != 0;
-    }
-
-    private boolean matchesPrefix(List<String> prefixes, String item, String type) {
-        boolean matches = prefixes.size() == 0 || prefixes.stream().anyMatch(item::startsWith);
-        LOGGER.debug(String.format("%s %s matches %s with %s", type, item, matches, prefixes));
-        return matches;
-    }
+  private boolean matchesPrefix(List<String> prefixes, String item, String type) {
+    boolean matches = prefixes.size() == 0 || prefixes.stream().anyMatch(item::startsWith);
+    LOGGER.debug(String.format("%s %s matches %s with %s", type, item, matches, prefixes));
+    return matches;
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
@@ -49,8 +49,10 @@ public class ResourceFilter {
             return matchesSubjectPrefixList(resourceName);
         } else if ("GROUP".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
             return matchesGroupPrefixList(resourceName);
+        } else {
+            // Nothing to filter out here
+            return true;
         }
-        return false;
     }
 
     private boolean matchesTopicPrefixList(String topic) {

--- a/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/ResourceFilter.java
@@ -1,6 +1,5 @@
 package com.purbon.kafka.topology.roles;
 
-import com.purbon.kafka.topology.AccessControlManager;
 import com.purbon.kafka.topology.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,11 +13,13 @@ public class ResourceFilter {
     private final List<String> managedServiceAccountPrefixes;
     private final List<String> managedTopicPrefixes;
     private final List<String> managedGroupPrefixes;
+    private final List<String> managedSubjectPrefixes;
 
     public ResourceFilter(Configuration config) {
         this.managedServiceAccountPrefixes = config.getServiceAccountManagedPrefixes();
         this.managedTopicPrefixes = config.getTopicManagedPrefixes();
         this.managedGroupPrefixes = config.getGroupManagedPrefixes();
+        this.managedSubjectPrefixes = config.getSubjectManagedPrefixes();
     }
 
     public boolean matchesManagedPrefixList(TopologyAclBinding topologyAclBinding) {
@@ -26,24 +27,26 @@ public class ResourceFilter {
         String principle = topologyAclBinding.getPrincipal();
         // For global wild cards ACL's we manage only if we manage the service account/principle,
         // regardless. Filtering by service account will always take precedence if defined
-        if (haveServiceAccountPrefixFilters() || resourceName.equals("*")) {
+        if (hasServiceAccountPrefixFilters() || resourceName.equals("*")) {
             if (resourceName.equals("*")) {
                 return matchesServiceAccountPrefixList(principle);
             } else {
                return matchesServiceAccountPrefixList(principle)
-                       && matchesTopicOrGroupPrefix(topologyAclBinding, resourceName);
+                       && matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
             }
-        } else if (haveTopicNamePrefixFilter() || haveGroupNamePrefixFilter()) {
-            return matchesTopicOrGroupPrefix(topologyAclBinding, resourceName);
+        } else if (hasTopicNamePrefixFilter() || hasGroupNamePrefixFilter() || hasSubjectNamePrefixFilter()) {
+            return matchesTopicOrSubjectOrGroupPrefix(topologyAclBinding, resourceName);
         }
 
         return true; // should include everything if not properly excluded earlier.
     }
 
-    private boolean matchesTopicOrGroupPrefix(
+    private boolean matchesTopicOrSubjectOrGroupPrefix(
             TopologyAclBinding topologyAclBinding, String resourceName) {
         if ("TOPIC".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
             return matchesTopicPrefixList(resourceName);
+        } else if ("SUBJECT".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
+            return matchesSubjectPrefixList(resourceName);
         } else if ("GROUP".equalsIgnoreCase(topologyAclBinding.getResourceType())) {
             return matchesGroupPrefixList(resourceName);
         }
@@ -58,25 +61,33 @@ public class ResourceFilter {
         return matchesPrefix(managedGroupPrefixes, group, "Group");
     }
 
+    private boolean matchesSubjectPrefixList(String subject) {
+        return matchesPrefix(managedSubjectPrefixes, subject, "Subject");
+    }
+
     private boolean matchesServiceAccountPrefixList(String principal) {
         return matchesPrefix(managedServiceAccountPrefixes, principal, "Principal");
     }
 
-    private boolean haveServiceAccountPrefixFilters() {
+    private boolean hasServiceAccountPrefixFilters() {
         return managedServiceAccountPrefixes.size() != 0;
     }
 
-    private boolean haveTopicNamePrefixFilter() {
+    private boolean hasTopicNamePrefixFilter() {
         return managedTopicPrefixes.size() != 0;
     }
 
-    private boolean haveGroupNamePrefixFilter() {
+    private boolean hasGroupNamePrefixFilter() {
         return managedGroupPrefixes.size() != 0;
+    }
+
+    private boolean hasSubjectNamePrefixFilter() {
+        return managedSubjectPrefixes.size() != 0;
     }
 
     private boolean matchesPrefix(List<String> prefixes, String item, String type) {
         boolean matches = prefixes.size() == 0 || prefixes.stream().anyMatch(item::startsWith);
-        LOGGER.debug(String.format("%s %s matches %s with $s", type, item, matches, prefixes));
+        LOGGER.debug(String.format("%s %s matches %s with %s", type, item, matches, prefixes));
         return matches;
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,6 +41,9 @@ topology {
     }
     managed.prefixes = []
   }
+  subject {
+    managed.prefixes = []
+  }
   project {
     prefix {
       format = "default"

--- a/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
@@ -305,7 +305,8 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void nonEmptyTopicManagedPrefixConfigsShouldValidateSuccessfully() throws ConfigurationException {
+  public void nonEmptyTopicManagedPrefixConfigsShouldValidateSuccessfully()
+      throws ConfigurationException {
     var topology = TestTopologyBuilder.createProject().buildTopology();
     props.put(TOPIC_MANAGED_PREFIXES + ".0", "foo");
     Configuration config = new Configuration(cliOps, props);

--- a/src/test/java/com/purbon/kafka/topology/ResourceFilterTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ResourceFilterTest.java
@@ -1,122 +1,90 @@
 package com.purbon.kafka.topology;
 
-import com.purbon.kafka.topology.roles.ResourceFilter;
-import com.purbon.kafka.topology.roles.TopologyAclBinding;
-import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Properties;
-
 import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
 import static com.purbon.kafka.topology.Constants.SERVICE_ACCOUNT_MANAGED_PREFIXES;
 import static com.purbon.kafka.topology.Constants.TOPIC_MANAGED_PREFIXES;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.purbon.kafka.topology.roles.ResourceFilter;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.util.HashMap;
+import java.util.Properties;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.Test;
+
 public class ResourceFilterTest {
 
-    @Test
-    public void resourcesWithPrincipalAndNameMatchesShouldBeFilter() {
-        Configuration config = makeConfig(new String[]{"User:foo"}, new String[]{"d.foo.bar"});
-        ResourceFilter filter = new ResourceFilter(config);
+  @Test
+  public void resourcesWithPrincipalAndNameMatchesShouldBeFilter() {
+    Configuration config = makeConfig(new String[] {"User:foo"}, new String[] {"d.foo.bar"});
+    ResourceFilter filter = new ResourceFilter(config);
 
-        TopologyAclBinding binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "d.foo.bar",
-                "*",
-                "read",
-                "User:foo",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "d.foo.bar", "*", "read", "User:foo", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
 
-        binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "d.foo.bar",
-                "*",
-                "read",
-                "User:bar",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
+    binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "d.foo.bar", "*", "read", "User:bar", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
 
-        binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "c.f.b",
-                "*",
-                "read",
-                "User:foo",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
+    binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "c.f.b", "*", "read", "User:foo", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
+  }
+
+  @Test
+  public void resourcesWithPrincipalMatchesShouldBeFiltered() {
+    Configuration config = makeConfig(new String[] {"User:foo"});
+    ResourceFilter filter = new ResourceFilter(config);
+
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "d.foo.bar", "*", "read", "User:foo", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
+  }
+
+  @Test
+  public void resourcesWithNamesMatchesShouldBeFiltered() {
+    Configuration config = makeConfigOnlyNames(new String[] {"d.foo.bar"});
+    ResourceFilter filter = new ResourceFilter(config);
+
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "d.foo.bar", "*", "read", "User:foo", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
+
+    binding =
+        TopologyAclBinding.build(
+            ResourceType.TOPIC.name(), "c.foo.zet", "*", "read", "User:foo", "PREFIXED");
+    assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
+  }
+
+  private Configuration makeConfigOnlyNames(String[] names) {
+    return makeConfig(new String[0], names);
+  }
+
+  private Configuration makeConfig(String[] principals) {
+    return makeConfig(principals, new String[0]);
+  }
+
+  private Configuration makeConfig(String[] principals, String[] names) {
+    HashMap<String, String> cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+    Properties props = new Properties();
+
+    for (int i = 0; i < principals.length; i++) {
+      String key = String.format("%s.%d", SERVICE_ACCOUNT_MANAGED_PREFIXES, i);
+      props.put(key, principals[i]);
     }
 
-
-    @Test
-    public void resourcesWithPrincipalMatchesShouldBeFiltered() {
-        Configuration config = makeConfig(new String[]{"User:foo"});
-        ResourceFilter filter = new ResourceFilter(config);
-
-        TopologyAclBinding binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "d.foo.bar",
-                "*",
-                "read",
-                "User:foo",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
+    for (int i = 0; i < names.length; i++) {
+      String key = String.format("%s.%d", TOPIC_MANAGED_PREFIXES, i);
+      props.put(key, names[i]);
     }
 
-    @Test
-    public void resourcesWithNamesMatchesShouldBeFiltered() {
-        Configuration config = makeConfigOnlyNames(new String[]{"d.foo.bar"});
-        ResourceFilter filter = new ResourceFilter(config);
-
-        TopologyAclBinding binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "d.foo.bar",
-                "*",
-                "read",
-                "User:foo",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isTrue();
-
-        binding = TopologyAclBinding.build(
-                ResourceType.TOPIC.name(),
-                "c.foo.zet",
-                "*",
-                "read",
-                "User:foo",
-                "PREFIXED"
-        );
-        assertThat(filter.matchesManagedPrefixList(binding)).isFalse();
-    }
-
-    private Configuration makeConfigOnlyNames(String[] names) {
-        return makeConfig(new String[0], names);
-    }
-    private Configuration makeConfig(String[] principals) {
-        return makeConfig(principals, new String[0]);
-    }
-
-
-    private Configuration makeConfig(String[] principals, String[] names) {
-        HashMap<String, String> cliOps = new HashMap<>();
-        cliOps.put(BROKERS_OPTION, "");
-        Properties props = new Properties();
-
-        for(int i=0; i < principals.length; i++) {
-            String key = String.format("%s.%d", SERVICE_ACCOUNT_MANAGED_PREFIXES, i);
-            props.put(key, principals[i]);
-        }
-
-        for(int i=0; i < names.length; i++) {
-            String key = String.format("%s.%d", TOPIC_MANAGED_PREFIXES, i);
-            props.put(key, names[i]);
-        }
-
-        return new Configuration(cliOps, props);
-    }
+    return new Configuration(cliOps, props);
+  }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
@@ -341,7 +341,6 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
 
     resources = apiClient.lookupResourcesForSchemaRegistry(schema.getPrincipal(), RESOURCE_OWNER);
     assertThat(resources).isEmpty();
-
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
@@ -95,6 +95,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
 
     Properties props = new Properties();
     props.put(ALLOW_DELETE_BINDINGS, true);
+    props.put(SUBJECT_MANAGED_PREFIXES + ".0", "managed");
 
     HashMap<String, String> cliOps = new HashMap<>();
     cliOps.put(BROKERS_OPTION, "");
@@ -294,7 +295,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
 
   @Test
   public void schemasRbacCreation() throws IOException {
-    var names = asList("foo", "bar");
+    var names = asList("managed.foo", "managed.bar", "not-managed.unused");
 
     Schemas schema = new Schemas();
     schema.setPrincipal("User:Schemas");
@@ -327,6 +328,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
 
     var resources =
         apiClient.lookupResourcesForSchemaRegistry(schema.getPrincipal(), RESOURCE_OWNER);
+    assertThat(resources.size()).isEqualTo(2);
     for (RbacResourceType resource : resources) {
       assertThat(names).contains(resource.getName());
       assertThat(resource.getResourceType()).isEqualTo("Subject");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduce the support of subject prefix filtering.


* **What is the current behavior?** (You can also link to an open issue here)
Currently it is not possible to define which subjects should be managed.


* **What is the new behavior (if this is a feature change)?**
As we can do with topics and groups, with this PR, we can now manage which subjects should be managed using prefixes.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

Fix #526.
