### PR TITLE
Feat/support env variable substitution in configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,6 +531,7 @@
     <log4j.version>2.17.1</log4j.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <commons.version>1.4</commons.version>
+    <commons-text.version>1.9</commons-text.version>
     <mockito.version>3.6.0</mockito.version>
     <junit.version>4.13.1</junit.version>
     <testcontainers.version>1.15.3</testcontainers.version>
@@ -735,7 +736,11 @@
       <version>2.33.1</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudApi.java
+++ b/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudApi.java
@@ -159,7 +159,7 @@ public class CCloudApi {
       throws IOException {
     String requestUrl = url;
     if (!url.contains("page_token")) {
-        requestUrl = String.format("%s?page_size=%d", url, page_size);
+      requestUrl = String.format("%s?page_size=%d", url, page_size);
     }
     Response r = ccloudApiHttpClient.doGet(requestUrl);
     return (ListServiceAccountResponse)

--- a/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACBindingsBuilder.java
@@ -452,13 +452,13 @@ public class RBACBindingsBuilder implements BindingsBuilderProvider {
       Boolean shouldOptimizeAcls,
       String namePrefix) {
     if (shouldOptimizeAcls) {
-      return setDetailedSchemaAuthorization(principal, role, namePrefix);
+      return setOptimizedSchemaAuthorization(principal, role, namePrefix);
     } else {
-      return setOptimizedSchemaAuthorization(principal, subjects, role, prefixed);
+      return setDetailedSchemaAuthorization(principal, subjects, role, prefixed);
     }
   }
 
-  private List<TopologyAclBinding> setDetailedSchemaAuthorization(
+  private List<TopologyAclBinding> setOptimizedSchemaAuthorization(
       String principal, String role, String namePrefix) {
     return List.of(
         apiClient
@@ -467,7 +467,7 @@ public class RBACBindingsBuilder implements BindingsBuilderProvider {
             .apply("SUBJECT", namePrefix, PatternType.PREFIXED.name()));
   }
 
-  private List<TopologyAclBinding> setOptimizedSchemaAuthorization(
+  private List<TopologyAclBinding> setDetailedSchemaAuthorization(
       String principal, List<String> subjects, String role, boolean prefixed) {
 
     String patternType = prefixed ? PatternType.PREFIXED.name() : PatternType.LITERAL.name();

--- a/src/main/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutor.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutor.java
@@ -1,53 +1,58 @@
 package com.purbon.kafka.topology.serdes;
 
 import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.status.StatusLogger;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-
 /**
- * A simple substitutor which substitutes system properties in the topology file.
- * If a property is not found, it throws a {@link com.purbon.kafka.topology.exceptions.TopologyParsingException}.
+ * A simple substitutor which substitutes system properties in the topology file. If a property is
+ * not found, it throws a {@link com.purbon.kafka.topology.exceptions.TopologyParsingException}.
  */
 public class SystemPropertySubstitutor {
   private final Map<String, String> env;
   private final StrSubstitutor strSubstitutor;
 
   public SystemPropertySubstitutor() {
-    env = System.getProperties().entrySet().stream()
-      .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
+    env =
+        System.getProperties().entrySet().stream()
+            .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
 
-    strSubstitutor = new StrSubstitutor(env, "${", "}") {
-      @Override
-      protected String resolveVariable(final LogEvent event, final String variableName, final StringBuilder buf,
-        final int startPos, final int endPos) {
-        String result = super.resolveVariable(event, variableName, buf, startPos, endPos);
-        if (result == null) {
-          throw new TopologyParsingException("Cannot resolve variable: " + variableName);
-        }
-        return result;
-      }
-
-      @Override
-      public String replace(final LogEvent event, final String source) {
-        if (source == null) {
-          return null;
-        }
-        final StringBuilder buf = new StringBuilder(source);
-        try {
-          if (!substitute(event, buf, 0, source.length())) {
-            return source;
+    strSubstitutor =
+        new StrSubstitutor(env, "${", "}") {
+          @Override
+          protected String resolveVariable(
+              final LogEvent event,
+              final String variableName,
+              final StringBuilder buf,
+              final int startPos,
+              final int endPos) {
+            String result = super.resolveVariable(event, variableName, buf, startPos, endPos);
+            if (result == null) {
+              throw new TopologyParsingException("Cannot resolve variable: " + variableName);
+            }
+            return result;
           }
-        } catch (Throwable t) {
-          StatusLogger.getLogger().error("Replacement failed on {}", source, t);
-          throw t;
-        }
-        return buf.toString();
-      }
-    };
+
+          @Override
+          public String replace(final LogEvent event, final String source) {
+            if (source == null) {
+              return null;
+            }
+            final StringBuilder buf = new StringBuilder(source);
+            try {
+              if (!substitute(event, buf, 0, source.length())) {
+                return source;
+              }
+            } catch (Throwable t) {
+              StatusLogger.getLogger().error("Replacement failed on {}", source, t);
+              throw t;
+            }
+            return buf.toString();
+          }
+        };
   }
 
   public String replace(String original) {

--- a/src/main/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutor.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutor.java
@@ -1,0 +1,56 @@
+package com.purbon.kafka.topology.serdes;
+
+import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.lookup.StrSubstitutor;
+import org.apache.logging.log4j.status.StatusLogger;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A simple substitutor which substitutes system properties in the topology file.
+ * If a property is not found, it throws a {@link com.purbon.kafka.topology.exceptions.TopologyParsingException}.
+ */
+public class SystemPropertySubstitutor {
+  private final Map<String, String> env;
+  private final StrSubstitutor strSubstitutor;
+
+  public SystemPropertySubstitutor() {
+    env = System.getProperties().entrySet().stream()
+      .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
+
+    strSubstitutor = new StrSubstitutor(env, "${", "}") {
+      @Override
+      protected String resolveVariable(final LogEvent event, final String variableName, final StringBuilder buf,
+        final int startPos, final int endPos) {
+        String result = super.resolveVariable(event, variableName, buf, startPos, endPos);
+        if (result == null) {
+          throw new TopologyParsingException("Cannot resolve variable: " + variableName);
+        }
+        return result;
+      }
+
+      @Override
+      public String replace(final LogEvent event, final String source) {
+        if (source == null) {
+          return null;
+        }
+        final StringBuilder buf = new StringBuilder(source);
+        try {
+          if (!substitute(event, buf, 0, source.length())) {
+            return source;
+          }
+        } catch (Throwable t) {
+          StatusLogger.getLogger().error("Replacement failed on {}", source, t);
+          throw t;
+        }
+        return buf.toString();
+      }
+    };
+  }
+
+  public String replace(String original) {
+    return strSubstitutor.replace(original);
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -86,7 +86,7 @@ public class TopologySerdesTest {
 
     // When
     Topology topology =
-      parser.deserialise(TestUtils.getResourceFile("/descriptor-with-system-properties.yaml"));
+        parser.deserialise(TestUtils.getResourceFile("/descriptor-with-system-properties.yaml"));
     Project project = topology.getProjects().get(0);
 
     // Then
@@ -101,8 +101,11 @@ public class TopologySerdesTest {
 
     // When
     // Then
-    assertThatThrownBy(() -> parser.deserialise(TestUtils.getResourceFile("/descriptor-with-unknown-system-properties.yaml")))
-      .isExactlyInstanceOf(TopologyParsingException.class);
+    assertThatThrownBy(
+            () ->
+                parser.deserialise(
+                    TestUtils.getResourceFile("/descriptor-with-unknown-system-properties.yaml")))
+        .isExactlyInstanceOf(TopologyParsingException.class);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/api/ccloud/CCloudApiTest.java
+++ b/src/test/java/com/purbon/kafka/topology/api/ccloud/CCloudApiTest.java
@@ -14,13 +14,11 @@ import com.purbon.kafka.topology.clients.JulieHttpClient;
 import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -130,70 +128,71 @@ public class CCloudApiTest {
   @Test
   public void listServiceAccountsShouldAcceptPage() throws IOException {
 
-    String body01 = "{\n" +
-            "  \"api_version\": \"iam/v2\",\n" +
-            "  \"kind\": \"ServiceAccountList\",\n" +
-            "  \"metadata\": {\n" +
-            "    \"first\": \"https://api.confluent.cloud/iam/v2/service-accounts\",\n" +
-            "    \"last\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=bcAOehAY8F16YD84Z1wT\",\n" +
-            "    \"prev\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=YIXRY97wWYmwzrax4dld\",\n" +
-            "    \"next\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=UvmDWOB1iwfAIBPj6EYb\",\n" +
-            "    \"total_size\": 123\n" +
-            "  },\n" +
-            "  \"data\": [\n" +
-            "    {\n" +
-            "      \"api_version\": \"iam/v2\",\n" +
-            "      \"kind\": \"ServiceAccount\",\n" +
-            "      \"id\": \"dlz-f3a90de\",\n" +
-            "      \"metadata\": {\n" +
-            "        \"self\": \"https://api.confluent.cloud/iam/v2/service-accounts/sa-12345\",\n" +
-            "        \"resource_name\": \"crn://confluent.cloud/service-account=sa-12345\",\n" +
-            "        \"created_at\": \"2006-01-02T15:04:05-07:00\",\n" +
-            "        \"updated_at\": \"2006-01-02T15:04:05-07:00\",\n" +
-            "        \"deleted_at\": \"2006-01-02T15:04:05-07:00\"\n" +
-            "      },\n" +
-            "      \"display_name\": \"DeLorean_auto_repair\",\n" +
-            "      \"description\": \"Doc's repair bot for the DeLorean\"\n" +
-            "    }\n" +
-            "  ]\n" +
-            "}";
+    String body01 =
+        "{\n"
+            + "  \"api_version\": \"iam/v2\",\n"
+            + "  \"kind\": \"ServiceAccountList\",\n"
+            + "  \"metadata\": {\n"
+            + "    \"first\": \"https://api.confluent.cloud/iam/v2/service-accounts\",\n"
+            + "    \"last\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=bcAOehAY8F16YD84Z1wT\",\n"
+            + "    \"prev\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=YIXRY97wWYmwzrax4dld\",\n"
+            + "    \"next\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=UvmDWOB1iwfAIBPj6EYb\",\n"
+            + "    \"total_size\": 123\n"
+            + "  },\n"
+            + "  \"data\": [\n"
+            + "    {\n"
+            + "      \"api_version\": \"iam/v2\",\n"
+            + "      \"kind\": \"ServiceAccount\",\n"
+            + "      \"id\": \"dlz-f3a90de\",\n"
+            + "      \"metadata\": {\n"
+            + "        \"self\": \"https://api.confluent.cloud/iam/v2/service-accounts/sa-12345\",\n"
+            + "        \"resource_name\": \"crn://confluent.cloud/service-account=sa-12345\",\n"
+            + "        \"created_at\": \"2006-01-02T15:04:05-07:00\",\n"
+            + "        \"updated_at\": \"2006-01-02T15:04:05-07:00\",\n"
+            + "        \"deleted_at\": \"2006-01-02T15:04:05-07:00\"\n"
+            + "      },\n"
+            + "      \"display_name\": \"DeLorean_auto_repair\",\n"
+            + "      \"description\": \"Doc's repair bot for the DeLorean\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
 
     Response response01 = new Response(null, 200, body01);
 
     when(httpClient.doGet(String.format("%s?page_size=%d", V2_IAM_SERVICE_ACCOUNTS_URL, 1)))
-            .thenReturn(response01);
+        .thenReturn(response01);
 
-    String body02 = "{\n" +
-            "  \"api_version\": \"iam/v2\",\n" +
-            "  \"kind\": \"ServiceAccountList\",\n" +
-            "  \"metadata\": {\n" +
-            "    \"first\": \"https://api.confluent.cloud/iam/v2/service-accounts\",\n" +
-            "    \"last\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=bcAOehAY8F16YD84Z1wT\",\n" +
-            "    \"prev\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=YIXRY97wWYmwzrax4dld\",\n" +
-            "    \"total_size\": 123\n" +
-            "  },\n" +
-            "  \"data\": [\n" +
-            "    {\n" +
-            "      \"api_version\": \"iam/v2\",\n" +
-            "      \"kind\": \"ServiceAccount\",\n" +
-            "      \"id\": \"abc-f3a90de\",\n" +
-            "      \"metadata\": {\n" +
-            "        \"self\": \"https://api.confluent.cloud/iam/v2/service-accounts/sa-12345\",\n" +
-            "        \"resource_name\": \"crn://confluent.cloud/service-account=sa-12345\",\n" +
-            "        \"created_at\": \"2006-01-02T15:04:05-07:00\",\n" +
-            "        \"updated_at\": \"2006-01-02T15:04:05-07:00\",\n" +
-            "        \"deleted_at\": \"2006-01-02T15:04:05-07:00\"\n" +
-            "      },\n" +
-            "      \"display_name\": \"MacFly\",\n" +
-            "      \"description\": \"Doc's repair bot for the MacFly\"\n" +
-            "    }\n" +
-            "  ]\n" +
-            "}";
+    String body02 =
+        "{\n"
+            + "  \"api_version\": \"iam/v2\",\n"
+            + "  \"kind\": \"ServiceAccountList\",\n"
+            + "  \"metadata\": {\n"
+            + "    \"first\": \"https://api.confluent.cloud/iam/v2/service-accounts\",\n"
+            + "    \"last\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=bcAOehAY8F16YD84Z1wT\",\n"
+            + "    \"prev\": \"https://api.confluent.cloud/iam/v2/service-accounts?page_token=YIXRY97wWYmwzrax4dld\",\n"
+            + "    \"total_size\": 123\n"
+            + "  },\n"
+            + "  \"data\": [\n"
+            + "    {\n"
+            + "      \"api_version\": \"iam/v2\",\n"
+            + "      \"kind\": \"ServiceAccount\",\n"
+            + "      \"id\": \"abc-f3a90de\",\n"
+            + "      \"metadata\": {\n"
+            + "        \"self\": \"https://api.confluent.cloud/iam/v2/service-accounts/sa-12345\",\n"
+            + "        \"resource_name\": \"crn://confluent.cloud/service-account=sa-12345\",\n"
+            + "        \"created_at\": \"2006-01-02T15:04:05-07:00\",\n"
+            + "        \"updated_at\": \"2006-01-02T15:04:05-07:00\",\n"
+            + "        \"deleted_at\": \"2006-01-02T15:04:05-07:00\"\n"
+            + "      },\n"
+            + "      \"display_name\": \"MacFly\",\n"
+            + "      \"description\": \"Doc's repair bot for the MacFly\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
     Response response02 = new Response(null, 200, body02);
 
-
     when(httpClient.doGet("/iam/v2/service-accounts?page_token=UvmDWOB1iwfAIBPj6EYb"))
-            .thenReturn(response02);
+        .thenReturn(response02);
 
     Set<ServiceAccount> accounts = apiClient.listServiceAccounts();
     assertThat(accounts).hasSize(2);

--- a/src/test/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutorTest.java
+++ b/src/test/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutorTest.java
@@ -1,0 +1,39 @@
+package com.purbon.kafka.topology.serdes;
+
+import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SystemPropertySubstitutorTest {
+  @Test
+  public void standardReplacement() {
+    // Given
+    System.getProperties().setProperty("env", "staging");
+    System.getProperties().setProperty("project", "my_project");
+    SystemPropertySubstitutor systemPropertySubstitutor = new SystemPropertySubstitutor();
+
+    // When
+    String result = systemPropertySubstitutor.replace(
+      "context: ${env}\n"
+      + "project: ${project}");
+
+    // Then
+    assertThat(result).isEqualTo(
+      "context: staging\n"
+        + "project: my_project"
+    );
+  }
+
+  @Test
+  public void notFoundKeyReplacement() {
+    // Given
+    SystemPropertySubstitutor systemPropertySubstitutor = new SystemPropertySubstitutor();
+
+    // When
+    // Then
+    assertThatThrownBy(() -> systemPropertySubstitutor.replace("${not_found_key}"))
+      .isExactlyInstanceOf(TopologyParsingException.class);
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutorTest.java
+++ b/src/test/java/com/purbon/kafka/topology/serdes/SystemPropertySubstitutorTest.java
@@ -1,10 +1,10 @@
 package com.purbon.kafka.topology.serdes;
 
-import com.purbon.kafka.topology.exceptions.TopologyParsingException;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import org.junit.Test;
 
 public class SystemPropertySubstitutorTest {
   @Test
@@ -15,15 +15,10 @@ public class SystemPropertySubstitutorTest {
     SystemPropertySubstitutor systemPropertySubstitutor = new SystemPropertySubstitutor();
 
     // When
-    String result = systemPropertySubstitutor.replace(
-      "context: ${env}\n"
-      + "project: ${project}");
+    String result = systemPropertySubstitutor.replace("context: ${env}\n" + "project: ${project}");
 
     // Then
-    assertThat(result).isEqualTo(
-      "context: staging\n"
-        + "project: my_project"
-    );
+    assertThat(result).isEqualTo("context: staging\n" + "project: my_project");
   }
 
   @Test
@@ -34,6 +29,6 @@ public class SystemPropertySubstitutorTest {
     // When
     // Then
     assertThatThrownBy(() -> systemPropertySubstitutor.replace("${not_found_key}"))
-      .isExactlyInstanceOf(TopologyParsingException.class);
+        .isExactlyInstanceOf(TopologyParsingException.class);
   }
 }

--- a/src/test/resources/descriptor-with-system-properties.yaml
+++ b/src/test/resources/descriptor-with-system-properties.yaml
@@ -1,0 +1,26 @@
+---
+context: ${env}
+source: ${source}
+projects:
+  - name: ${project}
+    consumers:
+      - principal: "User:App0"
+        metadata:
+          system: "OwnerSystem0"
+    producers:
+      - principal: "User:App1"
+        metadata:
+          contactInfo: "app1@company.com"
+    topics:
+      - name: "topicA"
+        consumers:
+          - principal: "User:App4"
+            metadata:
+              system: "OwnerSystem4"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+      - name: "topicB"
+        dataType: "avro"
+        schemas:
+          value.schema.file: "schemas/bar-value.avsc"

--- a/src/test/resources/descriptor-with-unknown-system-properties.yaml
+++ b/src/test/resources/descriptor-with-unknown-system-properties.yaml
@@ -1,0 +1,26 @@
+---
+context: ${unknown-env}
+source: ${source}
+projects:
+  - name: ${project}
+    consumers:
+      - principal: "User:App0"
+        metadata:
+          system: "OwnerSystem0"
+    producers:
+      - principal: "User:App1"
+        metadata:
+          contactInfo: "app1@company.com"
+    topics:
+      - name: "topicA"
+        consumers:
+          - principal: "User:App4"
+            metadata:
+              system: "OwnerSystem4"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+      - name: "topicB"
+        dataType: "avro"
+        schemas:
+          value.schema.file: "schemas/bar-value.avsc"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduce the support of system property substitution in the topology configuration files.


* **What is the new behavior (if this is a feature change)?**
Variable like `${environment}` can be used in topology files in order to simplify the usage of split topologies (per environment and project for instance).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



* **Other information**:
A small fix of function naming mixed up is present in a specific commit.
If needed I can push this fix in a separate PR.

