### PR TITLE
Add CreateArtefactAction even if the artefact already exists to allow connector updates

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
@@ -44,16 +44,14 @@ public abstract class ArtefactManager implements ExecutionPlanUpdater {
     for (Topology topology : topologies.values()) {
       Set<? extends Artefact> entryArtefacts = parseNewArtefacts(topology);
       for (Artefact artefact : entryArtefacts) {
-        if (!currentArtefacts.contains(artefact)) {
-          ArtefactClient client = selectClient(artefact);
-          if (client == null) {
-            throw new IOException(
-                "The Artefact "
-                    + artefact.getName()
-                    + " require a non configured client, please check our configuration");
-          }
-          plan.add(new CreateArtefactAction(client, rootPath(), currentArtefacts, artefact));
+        ArtefactClient client = selectClient(artefact);
+        if (client == null) {
+          throw new IOException(
+              "The Artefact "
+                  + artefact.getName()
+                  + " require a non configured client, please check our configuration");
         }
+        plan.add(new CreateArtefactAction(client, rootPath(), currentArtefacts, artefact));
         artefacts.add(artefact);
       }
     }

--- a/src/main/java/com/purbon/kafka/topology/actions/CreateArtefactAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/CreateArtefactAction.java
@@ -36,12 +36,10 @@ public class CreateArtefactAction extends BaseAction {
 
   @Override
   public void run() throws IOException {
-    if (!artefacts.contains(artefact)) {
-      LOGGER.info(
-          String.format(
-              "Creating artefact %s for client %s", artefact.getName(), client.getClass()));
-      client.add(artefact.getName(), content());
-    }
+    LOGGER.info(
+      String.format(
+          "Creating artefact %s for client %s", artefact.getName(), client.getClass()));
+    client.add(artefact.getName(), content());
   }
 
   public Artefact getArtefact() {


### PR DESCRIPTION
Since the artefact clients also support updates, remove the condition if the artefact already exists, so it will try to update it anyway.