### PR TITLE
Add plan name to deserialized topologies for validation uses

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/model/Topic.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topic.java
@@ -90,7 +90,8 @@ public class Topic implements Cloneable {
         dataType,
         config,
         appConfig,
-        appConfig.getTopicPrefixFormat());
+        appConfig.getTopicPrefixFormat(),
+        null);
   }
 
   public Topic(
@@ -100,7 +101,15 @@ public class Topic implements Cloneable {
       Optional<String> dataType,
       Map<String, String> config,
       Configuration appConfig) {
-    this(name, producers, consumers, dataType, config, appConfig, appConfig.getTopicPrefixFormat());
+    this(
+        name,
+        producers,
+        consumers,
+        dataType,
+        config,
+        appConfig,
+        appConfig.getTopicPrefixFormat(),
+        null);
   }
 
   public Topic(
@@ -110,7 +119,27 @@ public class Topic implements Cloneable {
       Optional<String> dataType,
       Map<String, String> config,
       Configuration appConfig,
-      String topicNamePattern) {
+      String plan) {
+    this(
+        name,
+        producers,
+        consumers,
+        dataType,
+        config,
+        appConfig,
+        appConfig.getTopicPrefixFormat(),
+        plan);
+  }
+
+  public Topic(
+      String name,
+      List<Producer> producers,
+      List<Consumer> consumers,
+      Optional<String> dataType,
+      Map<String, String> config,
+      Configuration appConfig,
+      String topicNamePattern,
+      String plan) {
     this.name = name;
     this.dlqPrefix = ""; // this topic is not a dlq topic
     this.producers = producers;
@@ -130,6 +159,8 @@ public class Topic implements Cloneable {
     }
     subjectNameStrategy = Optional.empty();
     this.topicNamePattern = topicNamePattern;
+
+    this.plan = plan;
   }
 
   public SubjectNameStrategy getSubjectNameStrategy() {
@@ -219,7 +250,8 @@ public class Topic implements Cloneable {
           getDataType(),
           getConfig(),
           getAppConfig(),
-          topicNamePattern);
+          topicNamePattern,
+          getPlan());
     }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopicCustomDeserializer.java
@@ -90,7 +90,15 @@ public class TopicCustomDeserializer extends StdDeserializer<Topic> {
                 "Topic \"" + name + "\" references non-existing plan \"" + planLabel + "\"");
           }
         });
-    Topic topic = new Topic(name, producers, consumers, optionalDataType, config, this.config);
+    Topic topic =
+        new Topic(
+            name,
+            producers,
+            consumers,
+            optionalDataType,
+            config,
+            this.config,
+            optionalPlanLabel.isPresent() ? optionalPlanLabel.get().asText() : null);
 
     Optional<SubjectNameStrategy> subjectNameStrategy =
         Optional.ofNullable(rootNode.get("subject.name.strategy"))

--- a/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyObjectBuilderTest.java
@@ -130,6 +130,9 @@ public class TopologyObjectBuilderTest {
     config.put("bar", "3");
     assertThat(topic.getConfig()).containsAllEntriesOf(config);
 
+    // should include the name of the plan for validation uses
+    assertThat(topic.getPlan()).isEqualTo("gold");
+
     // should respect values from the original config if not present in the plan description
     topic = map.get("barFoo");
     assertThat(topic.getConfig()).containsEntry("replication.factor", "1");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit messages are descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Modifies the TopicCustomDeserializer to add the plan name to deserialized topics
Implements #549

* **What is the current behavior?** (You can also link to an open issue here)
The current behavior adds plan configurations to the topic, but loses the original plan name. This results in `Topic.getPlan()` always returning null


* **What is the new behavior (if this is a feature change)?**
This PR modifies the TopicCustomDeserializer to include the plan name in the deserialized topic.
Topics that do not contain a plan continue to use `null`, rather than an Optional. This was to maintain backwards compatibility with the current interface


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:


**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING