### PR TITLE
ci: Lower-case maven for Dependabot (fixes nightly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "Maven" # See documentation for possible values
+  - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Ref [failing Dependabot actions](https://github.com/kafka-ops/julie/runs/16721025360).
