### PR TITLE
ci: Give just one lifecycle phase to maven (fixes nightly)

### DIFF
--- a/.github/workflows/nightly-artifacts-build.yml
+++ b/.github/workflows/nightly-artifacts-build.yml
@@ -79,7 +79,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Publish package
-        run: mvn verify -Dgpg.passphrase="$GPG_PASSPHRASE" --batch-mode deploy
+        run: mvn -Dgpg.passphrase="$GPG_PASSPHRASE" --batch-mode deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/release-artifacts-build.yml
+++ b/.github/workflows/release-artifacts-build.yml
@@ -42,7 +42,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn verify -Dgpg.passphrase="$GPG_PASSPHRASE" --batch-mode deploy
+        run: mvn -Dgpg.passphrase="$GPG_PASSPHRASE" --batch-mode deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Ref [failing Maven builds](https://github.com/kafka-ops/julie/actions/runs/6161550014/job/16721027019).

`mvn deploy` also includes `verify`. By giving both `verify` and `deploy`, the newer version of `maven-source-plugin` complains.
