### PR TITLE
Housekeeping changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ logs/*
 *.iml
 _build
 *~
-
 dependency-reduced-pom.xml
 server-api/logs/
 example/topology-builder-with-schema-cloud.properties
@@ -15,3 +14,4 @@ release/
 private.key
 rpm-gen-key
 .s3/
+.mvn

--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,7 @@
           </execution>
         </executions>
         <configuration>
-          <source>8</source>
+          <source>11</source>
           <additionalOptions>
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>

--- a/pom.xml
+++ b/pom.xml
@@ -585,11 +585,6 @@
       <version>${jinjava.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>${jedis.version}</version>
@@ -662,31 +657,32 @@
       <artifactId>jersey-common</artifactId>
       <version>${jersey.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
@@ -782,6 +778,13 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
         <version>${gcp.java.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,53 +168,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.0</version>
-        <configuration>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
-              </excludes>
-            </filter>
-          </filters>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>**/Log4j2Plugins.dat</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.purbon.kafka.topology.CommandLineInterface</mainClass>
-                  <manifestEntries>
-                    <Multi-Release>true</Multi-Release>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
@@ -470,6 +423,53 @@
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.purbon.kafka.topology.CommandLineInterface</mainClass>
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -629,6 +629,10 @@
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>logback-core</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -651,6 +655,12 @@
       <groupId>io.confluent.ksql</groupId>
       <artifactId>ksqldb-api-client</artifactId>
       <version>${ksqldb.client.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -684,15 +694,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
+
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
@@ -778,6 +791,20 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
         <version>${gcp.java.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,7 @@
     <log4j.version>2.20.0</log4j.version>
     <lombok.version>1.18.28</lombok.version>
     <mockito.version>5.5.0</mockito.version>
+    <slf4j.version>2.0.9</slf4j.version>
     <testcontainers.version>1.19.0</testcontainers.version>
     <typesafe.version>1.4.2</typesafe.version>
     <zookeeper.version>3.9.0</zookeeper.version>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -1,51 +1,30 @@
-Configuration:
+configuration:
   status: warn
 
   appenders:
-    Console:
-      name: LogToConsole
-      PatternLayout:
-        Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
+    console:
+      name: Console
+      patternLayout:
+        Pattern: "[%-5level] %d{HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 
-    #File:
-    #  name: File
-    #  fileName: logs/app.log
-    #  PatternLayout:
-    #    Pattern: "%d %p %C{1.} [%t] %m%n"
-
-    RollingFile:
-    - name: LogToRollingFile
-      fileName: logs/app.log
-      filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
-      Policies:
-        SizeBasedTriggeringPolicy:
-          size: 10MB
-      DefaultRollOverStrategy:
-        max: 10
-
-  Loggers:
+  loggers:
     logger:
       - name: com.purbon.kafka
-        level: debug
-        additivity: false
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
+        level: info
       - name: com.purbon.kafka.topology
         level: info
-        additivity: true
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
       - name: com.purbon.kafka.topology.api.mds
         level: info
-        additivity: true
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
-    Root:
-      level: error
-      AppenderRef:
-        ref: LogToConsole
+      - name: org.apache.kafka
+        level: warn
+      - name: org.apache.kafka.clients.admin.AdminClientConfig
+        level: error
+      - name: org.apache.kafka.clients.producer.ProducerConfig
+        level: error
+      - name: org.apache.kafka.clients.consumer.ConsumerConfig
+        level: error
+
+    root:
+      level: info
+      appenderRef:
+        ref: Console

--- a/src/test/resources/log4j2.yml
+++ b/src/test/resources/log4j2.yml
@@ -1,51 +1,30 @@
-Configuration:
+configuration:
   status: warn
 
   appenders:
-    Console:
-      name: LogToConsole
-      PatternLayout:
-        Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
+    console:
+      name: Console
+      patternLayout:
+        Pattern: "[%-5level] %d{HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 
-    #File:
-    #  name: File
-    #  fileName: logs/app.log
-    #  PatternLayout:
-    #    Pattern: "%d %p %C{1.} [%t] %m%n"
-
-    RollingFile:
-    - name: LogToRollingFile
-      fileName: logs/app.log
-      filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
-      Policies:
-        SizeBasedTriggeringPolicy:
-          size: 10MB
-      DefaultRollOverStrategy:
-        max: 10
-
-  Loggers:
+  loggers:
     logger:
       - name: com.purbon.kafka
         level: info
-        additivity: false
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
       - name: com.purbon.kafka.topology
         level: info
-        additivity: true
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
       - name: com.purbon.kafka.topology.api.mds
         level: info
-        additivity: true
-        AppenderRef:
-          - ref: LogToConsole
-          - ref: LogToRollingFile
-    Root:
+      - name: org.apache.kafka
+        level: warn
+      - name: org.apache.kafka.clients.admin.AdminClientConfig
+        level: error
+      - name: org.apache.kafka.clients.producer.ProducerConfig
+        level: error
+      - name: org.apache.kafka.clients.consumer.ConsumerConfig
+        level: error
+
+    root:
       level: info
-      AppenderRef:
-        ref: LogToConsole
+      appenderRef:
+        ref: Console


### PR DESCRIPTION
This change introduces project structure cleanup and some dependency refreshing.

Changes:
* Jackson dependencies imported via BOM to avoid multiple versioned declarations
* Logging switched to Log4j2 from outdated libraries
* Javadoc plugin moved before shade plugin to enable Java 11 compatibility (declared by compiler plugin); the plugin spammed build log with warnings about **var** keyword unsupported in Java 8.
