### PR TITLE
Fix quota manager integration

### DIFF
--- a/docker/rbac-sasl/create-roles.sh
+++ b/docker/rbac-sasl/create-roles.sh
@@ -30,52 +30,52 @@ C3=c3-cluster
 ################################### SETUP SUPERUSER ###################################
 echo "Creating Super User role bindings"
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL  \
     --role SystemAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID
+    --kafka-cluster $KAFKA_CLUSTER_ID
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL \
     --role SystemAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID \
-    --schema-registry-cluster-id $SR
+    --kafka-cluster $KAFKA_CLUSTER_ID \
+    --schema-registry-cluster $SR
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SUPER_USER_PRINCIPAL \
     --role SystemAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID \
-    --connect-cluster-id $CONNECT
+    --kafka-cluster $KAFKA_CLUSTER_ID \
+    --connect-cluster $CONNECT
 
 ################################### SCHEMA REGISTRY ###################################
 echo "Creating Schema Registry role bindings"
 
 # SecurityAdmin on SR cluster itself
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $SR_PRINCIPAL \
     --role SecurityAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID \
-    --schema-registry-cluster-id $SR
+    --kafka-cluster $KAFKA_CLUSTER_ID \
+    --schema-registry-cluster $SR
 
 # ResourceOwner for groups and topics on broker
 for resource in Topic:_schemas Group:schema-registry
 do
-    confluent iam rolebinding create \
+    confluent iam rbac role-binding create \
         --principal $SR_PRINCIPAL \
         --role ResourceOwner \
         --resource $resource \
-        --kafka-cluster-id $KAFKA_CLUSTER_ID
+        --kafka-cluster $KAFKA_CLUSTER_ID
 done
 
 ################################### CONNECT ###################################
 echo "Creating Connect role bindings"
 
 # SecurityAdmin on the connect cluster itself
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $CONNECT_PRINCIPAL \
     --role SecurityAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID \
-    --connect-cluster-id $CONNECT
+    --kafka-cluster $KAFKA_CLUSTER_ID \
+    --connect-cluster $CONNECT
 
 # ResourceOwner for groups and topics on broker
 declare -a ConnectResources=(
@@ -88,37 +88,37 @@ declare -a ConnectResources=(
 )
 for resource in ${ConnectResources[@]}
 do
-    confluent iam rolebinding create \
+    confluent iam rbac role-binding create \
         --principal $CONNECT_PRINCIPAL \
         --role ResourceOwner \
         --resource $resource \
-        --kafka-cluster-id $KAFKA_CLUSTER_ID
+        --kafka-cluster $KAFKA_CLUSTER_ID
 done
 
 ################################### C3 ###################################
 echo "Creating C3 role bindings"
 
 # C3 only needs SystemAdmin on the kafka cluster itself
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $C3_PRINCIPAL \
     --role SystemAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID
+    --kafka-cluster $KAFKA_CLUSTER_ID
 
 ################################### OTHER ROLE ###################################
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $OTHER_PRINCIPAL \
     --role DeveloperWrite \
     --resource "Topic:connect-configs" \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID
+    --kafka-cluster $KAFKA_CLUSTER_ID
 
 
-confluent iam rolebinding create \
+confluent iam rbac role-binding create \
     --principal $OTHER_PRINCIPAL \
     --role ResourceOwner \
     --resource "Topic:zaragoza." \
     --prefix \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID
+    --kafka-cluster $KAFKA_CLUSTER_ID
 
 echo "Finished setting up role bindings"
 echo "    kafka cluster id: $KAFKA_CLUSTER_ID"

--- a/docker/rbac-sasl/docker-compose.yml
+++ b/docker/rbac-sasl/docker-compose.yml
@@ -16,12 +16,13 @@ services:
     image: rroemhild/test-openldap
     hostname: openldap
     container_name: openldap
+    platform: linux/amd64
     ports:
       - "10389:10389"
     privileged: true
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.5.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -31,7 +32,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.0.1
+    image: confluentinc/cp-server:7.5.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -159,7 +160,7 @@ services:
       # CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.0.1
+    image: confluentinc/cp-schema-registry:7.5.0
     hostname: schema-registry
     container_name: schema-registry
     ports:
@@ -199,7 +200,7 @@ services:
       SCHEMA_REGISTRY_PUBLIC_KEY_PATH: /tmp/conf/public.pem
 
   connect:
-    image: confluentinc/cp-server-connect:7.0.1
+    image: confluentinc/cp-server-connect:7.5.0
     hostname: connect
     container_name: connect
     depends_on:
@@ -292,7 +293,7 @@ services:
                                                                           metadataServerUrls="http://broker:8090";
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:7.0.1
+    image: confluentinc/cp-enterprise-control-center:7.5.0
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/docs/handling-delete.rst
+++ b/docs/handling-delete.rst
@@ -31,9 +31,17 @@ The user can control topic deletion by:
 - setting the *allow.delete.topics* configuration in the provided file to the tool.
 - set the ENV variable *ALLOW_DELETE_TOPICS* when calling the tool from the CLI.
 
+Quotas deletion flag
+^^^^^^^^^^^
+The user can control quota deletion by:
+
+- setting the *allow.delete.quotas* configuration in the provided file to the tool.
+- set the ENV variable *ALLOW_DELETE_QUOTAS* when calling the tool from the CLI.
+- **Warning**: no prefix management is implemented, therefore quotas must be managed in one unique file.
+
 Bindings deletion flag
 ^^^^^^^^^^^
-
+$
 The user can control bindings deletion by:
 
 - setting the *allow.delete.bindings* configuration in the provided file to the tool.

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -376,6 +376,10 @@ public class Configuration {
     return config.getBoolean(ALLOW_DELETE_TOPICS);
   }
 
+  public boolean isAllowDeleteQuotas() {
+    return config.getBoolean(ALLOW_DELETE_QUOTAS);
+  }
+
   public boolean isAllowDeleteBindings() {
     return config.getBoolean(ALLOW_DELETE_BINDINGS);
   }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -78,6 +78,7 @@ public class Constants {
   public static final String OPTIMIZED_ACLS_CONFIG = "topology.acls.optimized";
 
   public static final String ALLOW_DELETE_TOPICS = "allow.delete.topics";
+  public static final String ALLOW_DELETE_QUOTAS = "allow.delete.quotas";
   public static final String ALLOW_DELETE_BINDINGS = "allow.delete.bindings";
   static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
   public static final String ALLOW_DELETE_CONNECT_ARTEFACTS = "allow.delete.artefacts.connect";

--- a/src/main/java/com/purbon/kafka/topology/actions/quotas/CreateQuotasAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/quotas/CreateQuotasAction.java
@@ -1,0 +1,38 @@
+package com.purbon.kafka.topology.actions.quotas;
+
+import com.purbon.kafka.topology.actions.BaseAction;
+import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.users.Quota;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CreateQuotasAction extends BaseAction {
+  private final TopologyBuilderAdminClient adminClient;
+  private final List<Quota> quotas;
+
+  public CreateQuotasAction(TopologyBuilderAdminClient adminClient, List<Quota> quotas) {
+    this.adminClient = adminClient;
+    this.quotas = quotas;
+  }
+
+  @Override
+  public void run() throws IOException {
+    adminClient.assignQuotasPrincipal(quotas);
+  }
+
+  @Override
+  protected Map<String, Object> props() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("Operation", getClass().getName());
+    map.put("Quotas", quotas);
+    map.put("Action", "create");
+    return map;
+  }
+
+  @Override
+  protected List<Map<String, Object>> detailedProps() {
+    return List.of(props());
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/actions/quotas/DeleteQuotasAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/quotas/DeleteQuotasAction.java
@@ -1,0 +1,39 @@
+package com.purbon.kafka.topology.actions.quotas;
+
+import com.purbon.kafka.topology.actions.BaseAction;
+import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.User;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DeleteQuotasAction extends BaseAction {
+  private final TopologyBuilderAdminClient adminClient;
+  private final List<User> users;
+
+  public DeleteQuotasAction(TopologyBuilderAdminClient adminClient, List<String> users) {
+    this.adminClient = adminClient;
+    this.users = users.stream().map(User::new).collect(Collectors.toList());
+  }
+
+  @Override
+  public void run() throws IOException {
+    adminClient.removeQuotasPrincipal(users);
+  }
+
+  @Override
+  protected Map<String, Object> props() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("Operation", getClass().getName());
+    map.put("Users", users);
+    map.put("Action", "delete");
+    return map;
+  }
+
+  @Override
+  protected List<Map<String, Object>> detailedProps() {
+    return List.of(props());
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
@@ -256,31 +256,31 @@ public class TopologyBuilderAdminClient {
 
   public void assignQuotasPrincipal(Collection<Quota> quotas) {
     List<ClientQuotaAlteration> lstQuotasAlteration =
-            quotas.stream()
-                    .map(f -> new QuotasClientBindingsBuilder(f).build())
-                    .collect(Collectors.toList());
+        quotas.stream()
+            .map(f -> new QuotasClientBindingsBuilder(f).build())
+            .collect(Collectors.toList());
 
     this.adminClient.alterClientQuotas(lstQuotasAlteration).all();
   }
 
   public void removeQuotasPrincipal(Collection<User> users) {
     List<ClientQuotaAlteration> lstQuotasRemove =
-            users.stream()
-                    .map(
-                            f ->
-                                    new QuotasClientBindingsBuilder(
-                                            new Quota(
-                                                    f.getPrincipal(),
-                                                    Optional.empty(),
-                                                    Optional.empty(),
-                                                    Optional.empty()))
-                                            .build())
-                    .collect(Collectors.toList());
+        users.stream()
+            .map(
+                f ->
+                    new QuotasClientBindingsBuilder(
+                            new Quota(
+                                f.getPrincipal(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                        .build())
+            .collect(Collectors.toList());
     this.adminClient.alterClientQuotas(lstQuotasRemove);
   }
 
-  // TODO: Use this function to manage quota deletion
-  public Map<ClientQuotaEntity, Map<String, Double>> describeClientQuotas() throws ExecutionException, InterruptedException {
+  public Map<ClientQuotaEntity, Map<String, Double>> describeClientQuotas()
+      throws ExecutionException, InterruptedException {
     return this.adminClient.describeClientQuotas(ClientQuotaFilter.all()).entities().get();
   }
 

--- a/src/main/java/com/purbon/kafka/topology/model/users/platform/Kafka.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/platform/Kafka.java
@@ -2,7 +2,6 @@ package com.purbon.kafka.topology.model.users.platform;
 
 import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Quota;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/com/purbon/kafka/topology/model/users/platform/Kafka.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/platform/Kafka.java
@@ -1,6 +1,8 @@
 package com.purbon.kafka.topology.model.users.platform;
 
 import com.purbon.kafka.topology.model.User;
+import com.purbon.kafka.topology.model.users.Quota;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,10 +11,12 @@ public class Kafka {
 
   private Optional<List<User>> instances;
   private Optional<Map<String, List<User>>> rbac;
+  private Optional<List<Quota>> quotas;
 
   public Kafka() {
     instances = Optional.empty();
     rbac = Optional.empty();
+    quotas = Optional.empty();
   }
 
   public Optional<List<User>> getInstances() {
@@ -29,5 +33,13 @@ public class Kafka {
 
   public void setRbac(Optional<Map<String, List<User>>> rbac) {
     this.rbac = rbac;
+  }
+
+  public Optional<List<Quota>> getQuotas() {
+    return quotas;
+  }
+
+  public void setQuotas(Optional<List<Quota>> quotas) {
+    this.quotas = quotas;
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/quotas/QuotasManager.java
+++ b/src/main/java/com/purbon/kafka/topology/quotas/QuotasManager.java
@@ -1,8 +1,16 @@
 package com.purbon.kafka.topology.quotas;
 
 import com.purbon.kafka.topology.Configuration;
+import com.purbon.kafka.topology.ExecutionPlan;
+import com.purbon.kafka.topology.ExecutionPlanUpdater;
+import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Quota;
+
+import java.io.IOException;
+import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -13,46 +21,36 @@ import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class QuotasManager {
+public class QuotasManager implements ExecutionPlanUpdater {
 
   private static final Logger LOGGER = LogManager.getLogger(QuotasManager.class);
 
-  private final AdminClient adminClient;
+  private final TopologyBuilderAdminClient adminClient;
   // private final TopologyBuilderAdminClient adminClient;
   private final Configuration config;
 
-  public QuotasManager(AdminClient adminClient, Configuration config) {
+  public QuotasManager(TopologyBuilderAdminClient adminClient, Configuration config) {
     this.adminClient = adminClient;
     this.config = config;
   }
 
-  public void assignQuotasPrincipal(Collection<Quota> quotas) {
-    List<ClientQuotaAlteration> lstQuotasAlteration =
-        quotas.stream()
-            .map(f -> new QuotasClientBindingsBuilder(f).build())
-            .collect(Collectors.toList());
-
-    this.adminClient.alterClientQuotas(lstQuotasAlteration).all();
+  @Override
+  public void updatePlan(ExecutionPlan plan, Map<String, Topology> topologies) throws IOException {
+    // TODO: manage deletion of quotas, for now update quotas to a high enough value
+    for (Topology topology : topologies.values()) {
+      topology.getPlatform().getKafka().getQuotas().ifPresent(adminClient::assignQuotasPrincipal);
+    }
   }
 
-  public void removeQuotasPrincipal(Collection<User> users) {
-    List<ClientQuotaAlteration> lstQuotasRemove =
-        users.stream()
-            .map(
-                f ->
-                    new QuotasClientBindingsBuilder(
-                            new Quota(
-                                f.getPrincipal(),
-                                Optional.empty(),
-                                Optional.empty(),
-                                Optional.empty()))
-                        .build())
-            .collect(Collectors.toList());
-    this.adminClient.alterClientQuotas(lstQuotasRemove);
-  }
-
-  private void describeClientQuotas() throws ExecutionException, InterruptedException {
-    Map<ClientQuotaEntity, Map<String, Double>> quotasresult =
-        this.adminClient.describeClientQuotas(ClientQuotaFilter.all()).entities().get();
+  @Override
+  public void printCurrentState(PrintStream out) throws IOException {
+    try {
+      Map<ClientQuotaEntity, Map<String, Double>> clientQuotaEntityMapMap = adminClient.describeClientQuotas();
+      clientQuotaEntityMapMap.entrySet().forEach(clientQuotaEntityMapEntry -> {
+        out.println(clientQuotaEntityMapEntry.toString());
+      });
+    } catch (ExecutionException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/quotas/QuotasManager.java
+++ b/src/main/java/com/purbon/kafka/topology/quotas/QuotasManager.java
@@ -3,21 +3,17 @@ package com.purbon.kafka.topology.quotas;
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.ExecutionPlan;
 import com.purbon.kafka.topology.ExecutionPlanUpdater;
+import com.purbon.kafka.topology.actions.quotas.CreateQuotasAction;
+import com.purbon.kafka.topology.actions.quotas.DeleteQuotasAction;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
-import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topology;
-import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Quota;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
-import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,7 +22,6 @@ public class QuotasManager implements ExecutionPlanUpdater {
   private static final Logger LOGGER = LogManager.getLogger(QuotasManager.class);
 
   private final TopologyBuilderAdminClient adminClient;
-  // private final TopologyBuilderAdminClient adminClient;
   private final Configuration config;
 
   public QuotasManager(TopologyBuilderAdminClient adminClient, Configuration config) {
@@ -36,19 +31,99 @@ public class QuotasManager implements ExecutionPlanUpdater {
 
   @Override
   public void updatePlan(ExecutionPlan plan, Map<String, Topology> topologies) throws IOException {
-    // TODO: manage deletion of quotas, for now update quotas to a high enough value
-    for (Topology topology : topologies.values()) {
-      topology.getPlatform().getKafka().getQuotas().ifPresent(adminClient::assignQuotasPrincipal);
+    // Get current quotas
+    try {
+      Map<ClientQuotaEntity, Map<String, Double>> currentQuotas =
+          adminClient.describeClientQuotas();
+      Map<String, Map<String, Double>> currentUsersWithQuotas =
+          currentQuotas.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey().entries().get(ClientQuotaEntity.USER),
+                      Map.Entry::getValue));
+
+      Set<String> usersWithQuotasInTopology = new HashSet<>();
+      for (Topology topology : topologies.values()) {
+        topology
+            .getPlatform()
+            .getKafka()
+            .getQuotas()
+            .ifPresent(
+                quotas -> {
+                  quotas.forEach(
+                      quota -> {
+                        String principal = quota.getPrincipal();
+                        Map<String, Double> currentQuotasForPrincipal =
+                            currentUsersWithQuotas.get(principal);
+                        // Check quotas with already existing one
+                        if (currentQuotasForPrincipal == null
+                            || isQuotaUpdated(currentQuotasForPrincipal, quota)) {
+                          plan.add(new CreateQuotasAction(adminClient, quotas));
+                        }
+                        usersWithQuotasInTopology.add(principal);
+                      });
+                });
+      }
+      // Check for deletion, no prefixes here, all quotas should be put in one unique file
+      if (config.isAllowDeleteQuotas()) {
+        usersWithQuotasInTopology.forEach(currentUsersWithQuotas::remove);
+        if (!currentUsersWithQuotas.isEmpty()) {
+          plan.add(
+              new DeleteQuotasAction(
+                  adminClient, new ArrayList<>(currentUsersWithQuotas.keySet())));
+        }
+      }
+    } catch (ExecutionException | InterruptedException e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  private boolean isQuotaUpdated(Map<String, Double> currentQuotasForPrincipal, Quota quota) {
+    Double consumerByteRate = currentQuotasForPrincipal.get("consumer_byte_rate");
+    if (quota.getConsumer_byte_rate().isEmpty() && consumerByteRate != null
+        || consumerByteRate == null && quota.getConsumer_byte_rate().isPresent()) {
+      return true;
+    } else if (consumerByteRate != null && quota.getConsumer_byte_rate().isPresent()) {
+      if (!consumerByteRate.equals(quota.getConsumer_byte_rate().get())) {
+        return true;
+      }
+    }
+
+    Double producerByteRate = currentQuotasForPrincipal.get("producer_byte_rate");
+    if (quota.getProducer_byte_rate().isEmpty() && producerByteRate != null
+        || producerByteRate == null && quota.getProducer_byte_rate().isPresent()) {
+      return true;
+    } else if (producerByteRate != null && quota.getProducer_byte_rate().isPresent()) {
+      if (!producerByteRate.equals(quota.getProducer_byte_rate().get())) {
+        return true;
+      }
+    }
+
+    Double requestPercentage = currentQuotasForPrincipal.get("request_percentage");
+    if (quota.getRequest_percentage().isEmpty() && requestPercentage != null
+        || requestPercentage == null && quota.getRequest_percentage().isPresent()) {
+      return true;
+    } else if (requestPercentage != null && quota.getRequest_percentage().isPresent()) {
+      if (!requestPercentage.equals(quota.getRequest_percentage().get())) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   @Override
   public void printCurrentState(PrintStream out) throws IOException {
+    out.println("List of Quotas:");
     try {
-      Map<ClientQuotaEntity, Map<String, Double>> clientQuotaEntityMapMap = adminClient.describeClientQuotas();
-      clientQuotaEntityMapMap.entrySet().forEach(clientQuotaEntityMapEntry -> {
-        out.println(clientQuotaEntityMapEntry.toString());
-      });
+      Map<ClientQuotaEntity, Map<String, Double>> clientQuotaEntityMapMap =
+          adminClient.describeClientQuotas();
+      clientQuotaEntityMapMap
+          .entrySet()
+          .forEach(
+              clientQuotaEntityMapEntry -> {
+                out.println(clientQuotaEntityMapEntry.toString());
+              });
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -158,6 +158,8 @@ allow {
     bindings = ${?ALLOW_DELETE_BINDINGS}
     principals = false
     principals = ${?ALLOW_DELETE_PRINCIPALS}
+    quotas = false
+    quotas = ${?ALLOW_DELETE_QUOTAS}
     artefacts {
         connect = false
         connect = ${?ALLOW_DELETE_ARTEFACTS_CONNECT}

--- a/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
+++ b/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
@@ -37,8 +37,7 @@ public class JulieOpsTest {
   @Mock AccessControlManager accessControlManager;
 
   @Mock KafkaConnectArtefactManager connectorManager;
-  @Mock
-  QuotasManager quotasManager;
+  @Mock QuotasManager quotasManager;
 
   @Mock KSqlArtefactManager ksqlArtefactManager;
 
@@ -46,8 +45,7 @@ public class JulieOpsTest {
 
   @Mock RedisBackend stateProcessor;
 
-  @Mock
-  PrintStream mockPrintStream;
+  @Mock PrintStream mockPrintStream;
 
   private Map<String, String> cliOps;
   private Properties props;
@@ -176,12 +174,12 @@ public class JulieOpsTest {
     ExecutionPlan plan = ExecutionPlan.init(backendController, mockPrintStream);
 
     JulieOps builder =
-            JulieOps.build(
-                    fileOrDirPath,
-                    builderConfig,
-                    topologyAdminClient,
-                    accessControlProvider,
-                    bindingsBuilderProvider);
+        JulieOps.build(
+            fileOrDirPath,
+            builderConfig,
+            topologyAdminClient,
+            accessControlProvider,
+            bindingsBuilderProvider);
 
     builder.setTopicManager(topicManager);
     builder.setAccessControlManager(accessControlManager);
@@ -189,7 +187,9 @@ public class JulieOpsTest {
     builder.setKSqlArtefactManager(ksqlArtefactManager);
     builder.setQuotasManager(quotasManager);
 
-    doNothing().when(builder.getAccessControlManager()).updatePlan(any(ExecutionPlan.class), any(Map.class));
+    doNothing()
+        .when(builder.getAccessControlManager())
+        .updatePlan(any(ExecutionPlan.class), any(Map.class));
     doNothing().when(topicManager).updatePlan(any(ExecutionPlan.class), any(Map.class));
     doNothing().when(quotasManager).updatePlan(any(ExecutionPlan.class), any(Map.class));
     doNothing().when(accessControlManager).updatePlan(any(ExecutionPlan.class), any(Map.class));

--- a/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
+++ b/src/test/java/com/purbon/kafka/topology/JulieOpsTest.java
@@ -9,8 +9,10 @@ import com.purbon.kafka.topology.audit.VoidAuditor;
 import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.exceptions.TopologyParsingException;
+import com.purbon.kafka.topology.quotas.QuotasManager;
 import com.purbon.kafka.topology.utils.TestUtils;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -35,12 +37,17 @@ public class JulieOpsTest {
   @Mock AccessControlManager accessControlManager;
 
   @Mock KafkaConnectArtefactManager connectorManager;
+  @Mock
+  QuotasManager quotasManager;
 
   @Mock KSqlArtefactManager ksqlArtefactManager;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Mock RedisBackend stateProcessor;
+
+  @Mock
+  PrintStream mockPrintStream;
 
   private Map<String, String> cliOps;
   private Properties props;
@@ -157,6 +164,40 @@ public class JulieOpsTest {
     verify(topicManager, times(1)).updatePlan(any(ExecutionPlan.class), any(Map.class));
     verify(accessControlManager, times(1)).updatePlan(any(ExecutionPlan.class), any(Map.class));
     verify(connectorManager, times(1)).updatePlan(any(ExecutionPlan.class), any(Map.class));
+  }
+
+  @Test
+  public void builderQuotaTest() throws Exception {
+    String fileOrDirPath = TestUtils.getResourceFilename("/descriptor-with-quotasonly.yaml");
+
+    Configuration builderConfig = new Configuration(cliOps, props);
+
+    BackendController backendController = new BackendController();
+    ExecutionPlan plan = ExecutionPlan.init(backendController, mockPrintStream);
+
+    JulieOps builder =
+            JulieOps.build(
+                    fileOrDirPath,
+                    builderConfig,
+                    topologyAdminClient,
+                    accessControlProvider,
+                    bindingsBuilderProvider);
+
+    builder.setTopicManager(topicManager);
+    builder.setAccessControlManager(accessControlManager);
+    builder.setConnectorManager(connectorManager);
+    builder.setKSqlArtefactManager(ksqlArtefactManager);
+    builder.setQuotasManager(quotasManager);
+
+    doNothing().when(builder.getAccessControlManager()).updatePlan(any(ExecutionPlan.class), any(Map.class));
+    doNothing().when(topicManager).updatePlan(any(ExecutionPlan.class), any(Map.class));
+    doNothing().when(quotasManager).updatePlan(any(ExecutionPlan.class), any(Map.class));
+    doNothing().when(accessControlManager).updatePlan(any(ExecutionPlan.class), any(Map.class));
+
+    builder.run();
+    builder.close();
+
+    verify(quotasManager, times(1)).updatePlan(any(ExecutionPlan.class), any(Map.class));
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
@@ -2,20 +2,21 @@ package com.purbon.kafka.topology.integration;
 
 import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
 import static com.purbon.kafka.topology.Constants.*;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.purbon.kafka.topology.*;
+import com.purbon.kafka.topology.actions.Action;
+import com.purbon.kafka.topology.actions.quotas.CreateQuotasAction;
+import com.purbon.kafka.topology.actions.quotas.DeleteQuotasAction;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.integration.containerutils.*;
+import com.purbon.kafka.topology.model.*;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;
-import com.purbon.kafka.topology.model.Project;
-import com.purbon.kafka.topology.model.Topic;
-import com.purbon.kafka.topology.model.Topology;
-import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.Producer;
 import com.purbon.kafka.topology.model.users.Quota;
+import com.purbon.kafka.topology.model.users.platform.Kafka;
 import com.purbon.kafka.topology.quotas.QuotasManager;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
 import com.purbon.kafka.topology.roles.acls.AclsBindingsBuilder;
@@ -41,6 +42,8 @@ public class QuotasManagerIT {
 
   private ExecutionPlan plan;
   private BackendController cs;
+
+  private Configuration config;
 
   private QuotasManager quotasManager;
   private AclsBindingsBuilder bindingsBuilder;
@@ -76,7 +79,7 @@ public class QuotasManagerIT {
     cliOps.put(BROKERS_OPTION, "");
     cliOps.put(CCLOUD_ENV_CONFIG, "");
 
-    Configuration config = new Configuration(cliOps, props);
+    config = new Configuration(cliOps, props);
 
     this.cs = new BackendController();
     this.plan = ExecutionPlan.init(cs, System.out);
@@ -89,7 +92,7 @@ public class QuotasManagerIT {
     accessControlManager = new AccessControlManager(aclsProvider, bindingsBuilder, config);
   }
 
-  private Topology woldMSpecPattern() throws ExecutionException, InterruptedException, IOException {
+  private Topology woldMSpecPattern() {
     List<Producer> producers = new ArrayList<>();
     Producer producer = new Producer("User:user1");
     producers.add(producer);
@@ -115,6 +118,133 @@ public class QuotasManagerIT {
     topology.addProject(project);
 
     return topology;
+  }
+
+  private Topology topologyWithQuotas() {
+    List<Producer> producers = new ArrayList<>();
+    Producer producer = new Producer("User:user1");
+    producers.add(producer);
+    Producer producer2 = new Producer("User:user2");
+    producers.add(producer2);
+
+    List<Consumer> consumers = new ArrayList<>();
+    Consumer consumer = new Consumer("User:user1");
+    consumers.add(consumer);
+    Consumer consumer2 = new Consumer("User:user2");
+    consumers.add(consumer2);
+
+    Project project = new ProjectImpl("project");
+    project.setProducers(producers);
+    project.setConsumers(consumers);
+
+    Topic topicA = new Topic("topicA");
+    project.addTopic(topicA);
+
+    Platform platform = new Platform();
+    Kafka kafka = new Kafka();
+    Quota quota = new Quota();
+    quota.setPrincipal("User:user1");
+    quota.setConsumer_byte_rate(Optional.of(1024d));
+    quota.setProducer_byte_rate(Optional.of(1024d));
+    quota.setRequest_percentage(Optional.of(80d));
+    kafka.setQuotas(Optional.of(List.of(quota)));
+    platform.setKafka(kafka);
+
+    Topology topology = new TopologyImpl();
+    topology.setContext("integration-test");
+    topology.addOther("source", "producerAclsCreation");
+    topology.addProject(project);
+    topology.setPlatform(platform);
+
+    return topology;
+  }
+
+  private Topology topologyWithoutQuotas() {
+    List<Producer> producers = new ArrayList<>();
+    Producer producer = new Producer("User:user1");
+    producers.add(producer);
+    Producer producer2 = new Producer("User:user2");
+    producers.add(producer2);
+
+    List<Consumer> consumers = new ArrayList<>();
+    Consumer consumer = new Consumer("User:user1");
+    consumers.add(consumer);
+    Consumer consumer2 = new Consumer("User:user2");
+    consumers.add(consumer2);
+
+    Project project = new ProjectImpl("project");
+    project.setProducers(producers);
+    project.setConsumers(consumers);
+
+    Topic topicA = new Topic("topicA");
+    project.addTopic(topicA);
+
+    Topology topology = new TopologyImpl();
+    topology.setContext("integration-test");
+    topology.addOther("source", "producerAclsCreation");
+    topology.addProject(project);
+
+    return topology;
+  }
+
+  @Test
+  public void planUpdateTesting() throws IOException {
+    // Test quota creation plan update
+    Topology topology = topologyWithQuotas();
+    quotasManager.updatePlan(topology, plan);
+    plan.run();
+
+    List<Action> actions = plan.getActions();
+
+    assertEquals(1, actions.size());
+    Action action = actions.get(0);
+    assertTrue(action instanceof CreateQuotasAction);
+
+    plan.getActions().clear();
+
+    // Test NOOP plan update
+    quotasManager.updatePlan(topology, plan);
+    plan.run();
+
+    actions = plan.getActions();
+
+    assertTrue(actions.isEmpty());
+
+    plan.getActions().clear();
+
+    // Test quota deletion plan update with deletion disabled
+    assertFalse(config.isAllowDeleteQuotas());
+    topology = topologyWithoutQuotas();
+    quotasManager.updatePlan(topology, plan);
+    plan.run();
+
+    actions = plan.getActions();
+    assertTrue(actions.isEmpty());
+
+    // Test quota deletion plan update with deletion enabled
+    // Enable quota deletion
+    Properties props = new Properties();
+    props.put(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER, "false");
+    props.put(ALLOW_DELETE_TOPICS, true);
+    props.put(ALLOW_DELETE_BINDINGS, true);
+    props.put(ALLOW_DELETE_QUOTAS, true);
+
+    HashMap<String, String> cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+    cliOps.put(CCLOUD_ENV_CONFIG, "");
+
+    config = new Configuration(cliOps, props);
+    quotasManager = new QuotasManager(topologyAdminClient, config);
+
+    assertTrue(config.isAllowDeleteQuotas());
+    topology = topologyWithoutQuotas();
+    quotasManager.updatePlan(topology, plan);
+    plan.run();
+
+    actions = plan.getActions();
+    assertEquals(1, actions.size());
+    action = actions.get(0);
+    assertTrue(action instanceof DeleteQuotasAction);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
@@ -83,7 +83,7 @@ public class QuotasManagerIT {
 
     this.topicManager = new TopicManager(topologyAdminClient, null, config);
     bindingsBuilder = new AclsBindingsBuilder(config);
-    quotasManager = new QuotasManager(kafkaAdminClient, config);
+    quotasManager = new QuotasManager(topologyAdminClient, config);
     aclsProvider = new SimpleAclsProvider(topologyAdminClient);
 
     accessControlManager = new AccessControlManager(aclsProvider, bindingsBuilder, config);
@@ -128,8 +128,7 @@ public class QuotasManagerIT {
     Quota quota = new Quota("user1", Optional.empty(), Optional.of(20.0));
     quotas.add(quota);
 
-    quotasManager.assignQuotasPrincipal(quotas);
-
+    topologyAdminClient.assignQuotasPrincipal(quotas);
     // Verify Quotas
     verifyQuotasOnlyUser(quotas);
   }
@@ -145,12 +144,12 @@ public class QuotasManagerIT {
     Quota quota = new Quota("user3", Optional.empty(), Optional.of(20.0));
     quotas.add(quota);
 
-    quotasManager.assignQuotasPrincipal(quotas);
+    topologyAdminClient.assignQuotasPrincipal(quotas);
     // Verify Quotas
     assertTrue(verifyQuotasOnlyUser(quotas).stream().allMatch(f -> f.equals(true)));
 
     // Remove quota
-    quotasManager.removeQuotasPrincipal(List.of(new User("user3")));
+    topologyAdminClient.removeQuotasPrincipal(List.of(new User("user3")));
     assertTrue(verifyQuotasOnlyUser(quotas).stream().allMatch(f -> f.equals(false)));
   }
 
@@ -165,7 +164,7 @@ public class QuotasManagerIT {
     List<Quota> quotas = new ArrayList<>();
     Quota quota = new Quota("user1", Optional.empty(), Optional.of(20.0));
     quotas.add(quota);
-    quotasManager.assignQuotasPrincipal(quotas);
+    topologyAdminClient.assignQuotasPrincipal(quotas);
     // Verify Quotas
     assertTrue(verifyQuotasOnlyUser(quotas).stream().allMatch(f -> f.equals(true)));
 
@@ -173,7 +172,7 @@ public class QuotasManagerIT {
     Quota quotaUpdate = new Quota("user1", Optional.of(150.0), Optional.of(250.0));
     quotas.clear();
     quotas.add(quotaUpdate);
-    quotasManager.assignQuotasPrincipal(quotas);
+    topologyAdminClient.assignQuotasPrincipal(quotas);
     assertTrue(verifyQuotasOnlyUser(quotas).stream().allMatch(f -> f.equals(true)));
   }
 
@@ -190,11 +189,11 @@ public class QuotasManagerIT {
     quotas.add(quota);
     Quota quota2 = new Quota("user2", Optional.of(300.0), Optional.of(100.0), Optional.of(50.0));
     quotas.add(quota2);
-    quotasManager.assignQuotasPrincipal(quotas);
+    topologyAdminClient.assignQuotasPrincipal(quotas);
     // Verify Quotas
     assertTrue(verifyQuotasOnlyUser(quotas).stream().allMatch(f -> f.equals(true)));
 
-    quotasManager.removeQuotasPrincipal(List.of(new User("user2")));
+    topologyAdminClient.removeQuotasPrincipal(List.of(new User("user2")));
     assertTrue(verifyQuotasOnlyUser(List.of(quota)).stream().allMatch(f -> f.equals(true)));
 
     assertTrue(verifyQuotasOnlyUser(List.of(quota2)).stream().allMatch(f -> f.equals(false)));


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes the integration and support of quotas in Julie Ops, including current state and deletion.

* **What is the current behavior?** (You can also link to an open issue here)

It does not work at all because the quota manager is not plugged and the data model does not contain quota declaration.

* **What is the new behavior (if this is a feature change)?**

Quotas are supported for creation, current state and deletion with as usual a flag to allow deletion.
No prefix management has been implemented because quotas are only using Users and therefore quotas should be declared in only one unique file. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:


**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING