### PR TITLE
chore: misc updates and improvements made while you were gone, take 2

### DIFF
--- a/.github/workflows/ci-integration-test-legacy.yml
+++ b/.github/workflows/ci-integration-test-legacy.yml
@@ -26,16 +26,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B clean integration-test -Pacls -Dcp.version=${{matrix.cpversion}} --file pom.xml

--- a/.github/workflows/ci-integration-test-main.yml
+++ b/.github/workflows/ci-integration-test-main.yml
@@ -15,21 +15,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java: [11.0.x]
-        cpversion: [7.5.0]
+        cpversion: [7.6.0]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B clean integration-test -Pacls -Dcp.version=${{matrix.cpversion}} --file pom.xml

--- a/.github/workflows/ci-unit-test-legacy.yml
+++ b/.github/workflows/ci-unit-test-legacy.yml
@@ -24,16 +24,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/ci-unit-test-main.yml
+++ b/.github/workflows/ci-unit-test-main.yml
@@ -19,16 +19,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/nightly-artifacts-build.yml
+++ b/.github/workflows/nightly-artifacts-build.yml
@@ -11,18 +11,14 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v1
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: copy fat jar
@@ -49,24 +45,21 @@ jobs:
     name: Build rpm/deb packages (using maven)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: "temurin"
+          cache: maven
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/release-artifacts-build-legacy.yml
+++ b/.github/workflows/release-artifacts-build-legacy.yml
@@ -9,17 +9,13 @@ jobs:
     name: Build rpm/deb packages (using maven)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 8
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Import private GPG key

--- a/.github/workflows/release-artifacts-build.yml
+++ b/.github/workflows/release-artifacts-build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build rpm/deb packages (using maven)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Import private GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4
@@ -22,22 +22,19 @@ jobs:
       - name: Import public GPG Key
         run: rpm --import release/keys/public.key
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: "temurin"
+          cache: maven
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/release-docker-legacy.yml
+++ b/.github/workflows/release-docker-legacy.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v1
       - name: Docker meta
         id: docker_meta
@@ -21,15 +21,11 @@ jobs:
               {{version}}
               {{major}}.{{minor}}
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 8
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: copy fat jar

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v1
       - name: Docker meta
         id: docker_meta
@@ -22,15 +22,11 @@ jobs:
               {{version}}
               {{major}}.{{minor}}
       - name: Set up the JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: "temurin"
+          cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: copy fat jar

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
       <plugin>
         <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.23</version>
         <configuration>
           <style>google</style>
         </configuration>
@@ -428,7 +428,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
         <configuration>
           <filters>
             <filter>
@@ -546,24 +546,24 @@
     <!-- dependencies -->
     <assertj.version>3.25.3</assertj.version>
     <avro.version>1.11.3</avro.version>
-    <aws.java.sdk.version>2.24.5</aws.java.sdk.version>
+    <aws.java.sdk.version>2.25.6</aws.java.sdk.version>
     <commons.version>1.6.0</commons.version>
     <confluent-ce.version>7.6.0-ce</confluent-ce.version>
     <confluent.version>7.6.0</confluent.version>
-    <gcp.java.sdk.version>26.32.0</gcp.java.sdk.version>
+    <gcp.java.sdk.version>26.34.0</gcp.java.sdk.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <jackson.version>2.16.1</jackson.version>
-    <jedis.version>4.4.6</jedis.version>
+    <jackson.version>2.16.2</jackson.version>
+    <jedis.version>4.4.7</jedis.version>
     <jersey.version>3.1.5</jersey.version>
     <jinjava.version>2.7.2</jinjava.version>
     <junit.version>4.13.2</junit.version>
     <ksqldb.client.version>7.0.0</ksqldb.client.version>
     <ksqldb.version>0.27.1</ksqldb.version>
-    <log4j.version>2.22.1</log4j.version>
+    <log4j.version>2.23.0</log4j.version>
     <lombok.version>1.18.30</lombok.version>
-    <mockito.version>5.10.0</mockito.version>
+    <mockito.version>5.11.0</mockito.version>
     <slf4j.version>2.0.12</slf4j.version>
-    <testcontainers.version>1.19.5</testcontainers.version>
+    <testcontainers.version>1.19.7</testcontainers.version>
     <typesafe.version>1.4.3</typesafe.version>
     <zookeeper.version>3.9.1</zookeeper.version>
   </properties>
@@ -720,7 +720,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.34.0</version>
+      <version>2.35.0</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -773,7 +773,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
-      <version>2.35.1</version>
+      <version>2.35.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
       <plugin>
         <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.1</version>
         <configuration>
           <style>google</style>
         </configuration>
@@ -408,7 +408,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -428,7 +428,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1</version>
         <configuration>
           <filters>
             <filter>
@@ -534,38 +534,38 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- plugins -->
-    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
-    <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
-    <maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
+    <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
+    <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
+    <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <rpm-maven-plugin.version>2.3.0</rpm-maven-plugin.version>
-    <spotbugs-maven-plugin.version>4.7.3.5</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.8.3.1</spotbugs-maven-plugin.version>
     <!-- dependencies -->
-    <assertj.version>3.24.2</assertj.version>
-    <avro.version>1.11.2</avro.version>
-    <aws.java.sdk.version>2.20.144</aws.java.sdk.version>
-    <commons.version>1.5.0</commons.version>
-    <confluent-ce.version>7.5.0-ce</confluent-ce.version>
-    <confluent.version>7.5.0</confluent.version>
-    <gcp.java.sdk.version>26.22.0</gcp.java.sdk.version>
+    <assertj.version>3.25.3</assertj.version>
+    <avro.version>1.11.3</avro.version>
+    <aws.java.sdk.version>2.24.5</aws.java.sdk.version>
+    <commons.version>1.6.0</commons.version>
+    <confluent-ce.version>7.6.0-ce</confluent-ce.version>
+    <confluent.version>7.6.0</confluent.version>
+    <gcp.java.sdk.version>26.32.0</gcp.java.sdk.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <jackson.version>2.15.2</jackson.version>
-    <jedis.version>4.4.4</jedis.version>
-    <jersey.version>3.1.3</jersey.version>
-    <jinjava.version>2.7.1</jinjava.version>
+    <jackson.version>2.16.1</jackson.version>
+    <jedis.version>4.4.6</jedis.version>
+    <jersey.version>3.1.5</jersey.version>
+    <jinjava.version>2.7.2</jinjava.version>
     <junit.version>4.13.2</junit.version>
     <ksqldb.client.version>7.0.0</ksqldb.client.version>
     <ksqldb.version>0.27.1</ksqldb.version>
-    <log4j.version>2.20.0</log4j.version>
-    <lombok.version>1.18.28</lombok.version>
-    <mockito.version>5.5.0</mockito.version>
-    <slf4j.version>2.0.9</slf4j.version>
-    <testcontainers.version>1.19.0</testcontainers.version>
-    <typesafe.version>1.4.2</typesafe.version>
-    <zookeeper.version>3.9.0</zookeeper.version>
+    <log4j.version>2.22.1</log4j.version>
+    <lombok.version>1.18.30</lombok.version>
+    <mockito.version>5.10.0</mockito.version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <testcontainers.version>1.19.5</testcontainers.version>
+    <typesafe.version>1.4.3</typesafe.version>
+    <zookeeper.version>3.9.1</zookeeper.version>
   </properties>
 
   <dependencies>
@@ -720,7 +720,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.26.1</version>
+      <version>2.34.0</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -81,9 +81,7 @@ public class AccessControlManager implements ExecutionPlanUpdater {
             .collect(Collectors.toSet());
 
     if (!config.shouldVerifyRemoteState()) {
-      LOGGER.warn(
-          "Remote state verification disabled, this is not a good practice, be aware"
-              + "in future versions, this check is going to become mandatory.");
+      OnceOnlyWarningLogger.getInstance().logRemoteStateVerificationDisabledWarning();
     }
 
     if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {

--- a/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
+++ b/src/main/java/com/purbon/kafka/topology/ArtefactManager.java
@@ -126,9 +126,7 @@ public abstract class ArtefactManager implements ExecutionPlanUpdater {
     var currentState = config.fetchStateFromTheCluster() ? getClustersState() : getLocalState(plan);
 
     if (!config.shouldVerifyRemoteState()) {
-      LOGGER.warn(
-          "Remote state verification disabled, this is not a good practice, be aware"
-              + "in future versions, this check is going to become mandatory.");
+      OnceOnlyWarningLogger.getInstance().logRemoteStateVerificationDisabledWarning();
     }
 
     if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {

--- a/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
+++ b/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
@@ -43,6 +43,12 @@ public class CommandLineInterface {
   public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION = "accept-read-only-streams";
   public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_DESC =
       "Don't warn for streams that only have readers. Use this if you abuse streams to have a lazy person's consumers with state.";
+
+  public static final String DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION =
+      "accept-projects-without-topics";
+  public static final String DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_DESC =
+      "Don't warn for projects without topics.";
+
   public static final String VALIDATE_OPTION = "validate";
   public static final String VALIDATE_DESC = "Only run configured validations in your topology";
 
@@ -120,6 +126,14 @@ public class CommandLineInterface {
             .required(false)
             .build();
 
+    final Option dontWarnForProjectsWithoutTopicsOption =
+        Option.builder()
+            .longOpt(DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION)
+            .hasArg(false)
+            .desc(DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_DESC)
+            .required(false)
+            .build();
+
     final Option quietOption =
         Option.builder()
             .longOpt(QUIET_OPTION)
@@ -158,6 +172,7 @@ public class CommandLineInterface {
     options.addOption(dryRunOption);
     options.addOption(recursiveOption);
     options.addOption(dontWarnForReadOnlyStreamsOption);
+    options.addOption(dontWarnForProjectsWithoutTopicsOption);
     options.addOption(quietOption);
     options.addOption(validateOption);
     options.addOption(versionOption);
@@ -197,6 +212,12 @@ public class CommandLineInterface {
     }
     config.put(DRY_RUN_OPTION, String.valueOf(cmd.hasOption(DRY_RUN_OPTION)));
     config.put(RECURSIVE_OPTION, String.valueOf(cmd.hasOption(RECURSIVE_OPTION)));
+    config.put(
+        DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION,
+        String.valueOf(cmd.hasOption(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION)));
+    config.put(
+        DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION,
+        String.valueOf(cmd.hasOption(DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION)));
     config.put(QUIET_OPTION, String.valueOf(cmd.hasOption(QUIET_OPTION)));
     config.put(VALIDATE_OPTION, String.valueOf(cmd.hasOption(VALIDATE_OPTION)));
     config.put(

--- a/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
+++ b/src/main/java/com/purbon/kafka/topology/CommandLineInterface.java
@@ -40,6 +40,9 @@ public class CommandLineInterface {
   public static final String QUIET_OPTION = "quiet";
   public static final String QUIET_DESC = "Print minimum status update";
 
+  public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION = "accept-read-only-streams";
+  public static final String DONT_WARN_FOR_READ_ONLY_STREAMS_DESC =
+      "Don't warn for streams that only have readers. Use this if you abuse streams to have a lazy person's consumers with state.";
   public static final String VALIDATE_OPTION = "validate";
   public static final String VALIDATE_DESC = "Only run configured validations in your topology";
 
@@ -109,6 +112,14 @@ public class CommandLineInterface {
             .required(false)
             .build();
 
+    final Option dontWarnForReadOnlyStreamsOption =
+        Option.builder()
+            .longOpt(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION)
+            .hasArg(false)
+            .desc(DONT_WARN_FOR_READ_ONLY_STREAMS_DESC)
+            .required(false)
+            .build();
+
     final Option quietOption =
         Option.builder()
             .longOpt(QUIET_OPTION)
@@ -146,6 +157,7 @@ public class CommandLineInterface {
     options.addOption(overridingAdminClientConfigFileOption);
     options.addOption(dryRunOption);
     options.addOption(recursiveOption);
+    options.addOption(dontWarnForReadOnlyStreamsOption);
     options.addOption(quietOption);
     options.addOption(validateOption);
     options.addOption(versionOption);

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -392,6 +392,12 @@ public class Configuration {
     return config.getBoolean(ALLOW_DELETE_KSQL_ARTEFACTS);
   }
 
+  public boolean isWarnIfReadOnlyStreams() {
+    return !Boolean.parseBoolean(
+            cliParams.getOrDefault(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION, "false"))
+        && config.getBoolean(STREAMS_WARN_IF_READ_ONLY);
+  }
+
   public boolean enabledPrincipalTranslation() {
     return config.getBoolean(TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG);
   }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -398,6 +398,12 @@ public class Configuration {
         && config.getBoolean(STREAMS_WARN_IF_READ_ONLY);
   }
 
+  public boolean isWarnIfProjectsWithoutTopics() {
+    return !Boolean.parseBoolean(
+            cliParams.getOrDefault(DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION, "false"))
+        && config.getBoolean(PROJECTS_WARN_IF_NO_TOPICS);
+  }
+
   public boolean enabledPrincipalTranslation() {
     return config.getBoolean(TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG);
   }

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -83,6 +83,7 @@ public class Constants {
   public static final String ALLOW_DELETE_CONNECT_ARTEFACTS = "allow.delete.artefacts.connect";
   public static final String ALLOW_DELETE_KSQL_ARTEFACTS = "allow.delete.artefacts.ksql";
   public static final String STREAMS_WARN_IF_READ_ONLY = "streams.warn-if.read-only";
+  public static final String PROJECTS_WARN_IF_NO_TOPICS = "projects.warn-if.no-topics";
   public static final String JULIE_ENABLE_PRINCIPAL_MANAGEMENT =
       "julie.enable.principal.management";
 

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -82,7 +82,7 @@ public class Constants {
   static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
   public static final String ALLOW_DELETE_CONNECT_ARTEFACTS = "allow.delete.artefacts.connect";
   public static final String ALLOW_DELETE_KSQL_ARTEFACTS = "allow.delete.artefacts.ksql";
-
+  public static final String STREAMS_WARN_IF_READ_ONLY = "streams.warn-if.read-only";
   public static final String JULIE_ENABLE_PRINCIPAL_MANAGEMENT =
       "julie.enable.principal.management";
 

--- a/src/main/java/com/purbon/kafka/topology/OnceOnlyWarningLogger.java
+++ b/src/main/java/com/purbon/kafka/topology/OnceOnlyWarningLogger.java
@@ -1,0 +1,27 @@
+package com.purbon.kafka.topology;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+class OnceOnlyWarningLogger {
+
+  private static final OnceOnlyWarningLogger INSTANCE = new OnceOnlyWarningLogger();
+  private static final Logger LOGGER = LogManager.getLogger(OnceOnlyWarningLogger.class);
+  private boolean remoteStateVerificationDisabledWarningShown = false;
+
+  private OnceOnlyWarningLogger() {}
+
+  public static OnceOnlyWarningLogger getInstance() {
+    return INSTANCE;
+  }
+
+  public void logRemoteStateVerificationDisabledWarning() {
+    if (remoteStateVerificationDisabledWarningShown) {
+      return;
+    }
+    LOGGER.warn(
+        "Remote state verification is disabled. This is not a good practice, "
+            + "and in future versions this check may become mandatory.");
+    remoteStateVerificationDisabledWarningShown = true;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/TopicManager.java
+++ b/src/main/java/com/purbon/kafka/topology/TopicManager.java
@@ -137,9 +137,7 @@ public class TopicManager implements ExecutionPlanUpdater {
               + StringUtils.join(new ArrayList<>(listOfTopics), ","));
 
     if (!config.shouldVerifyRemoteState()) {
-      LOGGER.warn(
-          "Remote state verification disabled, this is not a good practice, be aware"
-              + "in future versions, this check is going to become mandatory.");
+      OnceOnlyWarningLogger.getInstance().logRemoteStateVerificationDisabledWarning();
     }
 
     if (config.shouldVerifyRemoteState() && !config.fetchStateFromTheCluster()) {

--- a/src/main/java/com/purbon/kafka/topology/clients/JulieHttpClient.java
+++ b/src/main/java/com/purbon/kafka/topology/clients/JulieHttpClient.java
@@ -130,7 +130,10 @@ public class JulieHttpClient {
   }
 
   protected KeyManager[] getKeyManagersFromKeyStore(Configuration config)
-      throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException,
+      throws NoSuchAlgorithmException,
+          CertificateException,
+          KeyStoreException,
+          IOException,
           UnrecoverableKeyException {
     KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX");
     KeyStore ks = loadKeyStore(config.getSslKeyStoreLocation(), config.getSslKeyStorePassword());

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
@@ -423,15 +423,15 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
 
     for (KStream ks : streams) {
       var topics = ks.getTopics();
-      if (topics.get(KStream.READ_TOPICS).isEmpty() || topics.get(KStream.WRITE_TOPICS).isEmpty()) {
+      if (topics.get(KStream.WRITE_TOPICS).isEmpty() && config.isWarnIfReadOnlyStreams()) {
         LOGGER.warn(
             "A Kafka Streams application with Id ("
                 + ks.getApplicationId()
                 + ") and Principal ("
                 + ks.getPrincipal()
                 + ")"
-                + " might require both read and write topics as per its "
-                + "nature it is always reading and writing into Apache Kafka, be aware if you notice problems.");
+                + " might require both read and write topics, as per its "
+                + "nature, it is always reading and writing into Apache Kafka.");
       }
       if (topics.get(KStream.READ_TOPICS).isEmpty()) {
         // should have at minimum read topics defined as we could think of write topics as internal

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologyCustomDeserializer.java
@@ -252,11 +252,13 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
 
     var topicsNode = rootNode.get(TOPICS_KEY);
     if (topicsNode == null) {
-      LOGGER.warn(
-          TOPICS_KEY
-              + " is missing for project: "
-              + project.getName()
-              + ", this might be a required field, be aware.");
+      if (config.isWarnIfProjectsWithoutTopics()) {
+        LOGGER.warn(
+            TOPICS_KEY
+                + " is missing for project: "
+                + project.getName()
+                + ", this might be a required field, be aware.");
+      }
     } else {
       var allowList =
           config.getDlqTopicsAllowList().stream()

--- a/src/main/java/com/purbon/kafka/topology/utils/JSON.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/JSON.java
@@ -14,11 +14,15 @@ import java.util.Map;
 public class JSON {
 
   private static final ObjectMapper mapper;
+  private static final ObjectWriter prettyWriter;
 
   static {
     mapper = new ObjectMapper();
     mapper.registerModule(new Jdk8Module());
     mapper.findAndRegisterModules();
+    DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+    prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+    prettyWriter = mapper.writer(prettyPrinter);
   }
 
   public static Map<String, Object> toMap(String jsonString) throws JsonProcessingException {
@@ -30,7 +34,7 @@ public class JSON {
   }
 
   public static String asPrettyString(Map map) throws JsonProcessingException {
-    return getPrettyWriter().writeValueAsString(map);
+    return prettyWriter.writeValueAsString(map);
   }
 
   public static List<String> toArray(String jsonString) throws JsonProcessingException {
@@ -42,7 +46,7 @@ public class JSON {
   }
 
   public static String asPrettyString(Object object) throws JsonProcessingException {
-    return getPrettyWriter().writeValueAsString(object);
+    return prettyWriter.writeValueAsString(object);
   }
 
   public static Object toObjectList(String jsonString, Class objectClazz)
@@ -59,11 +63,5 @@ public class JSON {
 
   public static JsonNode toNode(String jsonString) throws JsonProcessingException {
     return mapper.readTree(jsonString);
-  }
-
-  private static ObjectWriter getPrettyWriter() {
-    DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
-    prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
-    return mapper.writer(prettyPrinter);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/utils/JSON.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/JSON.java
@@ -1,8 +1,11 @@
 package com.purbon.kafka.topology.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.util.List;
@@ -27,7 +30,7 @@ public class JSON {
   }
 
   public static String asPrettyString(Map map) throws JsonProcessingException {
-    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(map);
+    return getPrettyWriter().writeValueAsString(map);
   }
 
   public static List<String> toArray(String jsonString) throws JsonProcessingException {
@@ -39,7 +42,7 @@ public class JSON {
   }
 
   public static String asPrettyString(Object object) throws JsonProcessingException {
-    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+    return getPrettyWriter().writeValueAsString(object);
   }
 
   public static Object toObjectList(String jsonString, Class objectClazz)
@@ -56,5 +59,11 @@ public class JSON {
 
   public static JsonNode toNode(String jsonString) throws JsonProcessingException {
     return mapper.readTree(jsonString);
+  }
+
+  private static ObjectWriter getPrettyWriter() {
+    DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+    prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+    return mapper.writer(prettyPrinter);
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -179,3 +179,6 @@ validations {
 streams {
     warn-if.read-only = true
 }
+projects {
+    warn-if.no-topics = true
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -101,7 +101,6 @@ julie {
     verify.remote.state = false
     verify.remote.state = ${?JULIE_VERIFY_REMOTE_STATE}
 
-
     audit {
        enabled = false
        enabled = ${?JULIE_AUDIT_ENABLED}
@@ -175,4 +174,8 @@ validations {
         op = "gte"
         value = 3
     }
+}
+
+streams {
+    warn-if.read-only = true
 }

--- a/src/test/java/com/purbon/kafka/topology/CLITest.java
+++ b/src/test/java/com/purbon/kafka/topology/CLITest.java
@@ -38,12 +38,8 @@ public class CLITest {
 
     doNothing().when(cli).processTopology(eq("descriptor.yaml"), eq("default"), anyMap());
 
-    Map<String, String> config = new HashMap<>();
+    Map<String, String> config = getDefaultMap();
     config.put(BROKERS_OPTION, "localhost:9092");
-    config.put(DRY_RUN_OPTION, "false");
-    config.put(RECURSIVE_OPTION, "false");
-    config.put(QUIET_OPTION, "false");
-    config.put(VALIDATE_OPTION, "false");
     config.put(CLIENT_CONFIG_OPTION, "topology-builder-sasl-plain.properties");
     config.put(OVERRIDING_CLIENT_CONFIG_OPTION, null);
     cli.run(args);
@@ -63,16 +59,24 @@ public class CLITest {
 
     doNothing().when(cli).processTopology(eq("descriptor.yaml"), eq("default"), anyMap());
 
-    Map<String, String> config = new HashMap<>();
+    Map<String, String> config = getDefaultMap();
     config.put(BROKERS_OPTION, "localhost:9092");
     config.put(DRY_RUN_OPTION, "true");
-    config.put(RECURSIVE_OPTION, "false");
-    config.put(QUIET_OPTION, "false");
-    config.put(VALIDATE_OPTION, "false");
     config.put(CLIENT_CONFIG_OPTION, "topology-builder-sasl-plain.properties");
     config.put(OVERRIDING_CLIENT_CONFIG_OPTION, null);
     cli.run(args);
 
     verify(cli, times(1)).processTopology(eq("descriptor.yaml"), eq("default"), eq(config));
+  }
+
+  private Map<String, String> getDefaultMap() {
+    Map<String, String> map = new HashMap<>();
+    map.put(DRY_RUN_OPTION, "false");
+    map.put(RECURSIVE_OPTION, "false");
+    map.put(QUIET_OPTION, "false");
+    map.put(VALIDATE_OPTION, "false");
+    map.put(DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION, "false");
+    map.put(DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION, "false");
+    return map;
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Condition;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -335,5 +336,19 @@ public class ConfigurationTest {
     props.put(SERVICE_ACCOUNT_MANAGED_PREFIXES + ".0", "");
     Configuration config = new Configuration(cliOps, props);
     config.validateWith(topology);
+  }
+
+  @Test
+  public void shouldWarnForReadOnlyStreamsByDefaultToKeepBackwardsCompatibility() {
+    Configuration config = new Configuration(cliOps, props);
+    Assert.assertTrue(config.isWarnIfReadOnlyStreams());
+  }
+
+  @Test
+  public void shouldOverrideWarnForReadOnlyStreamsFromCommandLine() {
+    Map<String, String> localCliOps = new HashMap<>();
+    localCliOps.put(CommandLineInterface.DONT_WARN_FOR_READ_ONLY_STREAMS_OPTION, "true");
+    Configuration config = new Configuration(localCliOps, props);
+    Assert.assertFalse(config.isWarnIfReadOnlyStreams());
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ConfigurationTest.java
@@ -351,4 +351,18 @@ public class ConfigurationTest {
     Configuration config = new Configuration(localCliOps, props);
     Assert.assertFalse(config.isWarnIfReadOnlyStreams());
   }
+
+  @Test
+  public void shouldWarnForProjectsWithoutTopicsToKeepBackwardsCompatibility() {
+    Configuration config = new Configuration(cliOps, props);
+    Assert.assertTrue(config.isWarnIfProjectsWithoutTopics());
+  }
+
+  @Test
+  public void shouldOverrideWarnForProjectsWithoutTopicsFromCommandLine() {
+    Map<String, String> localCliOps = new HashMap<>();
+    localCliOps.put(CommandLineInterface.DONT_WARN_FOR_PROJECTS_WITHOUT_TOPICS_OPTION, "true");
+    Configuration config = new Configuration(localCliOps, props);
+    Assert.assertFalse(config.isWarnIfProjectsWithoutTopics());
+  }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -41,7 +41,7 @@ public class RedisBackendIT {
 
   @Rule
   public GenericContainer redis =
-      new GenericContainer<>(DockerImageName.parse("redis:5.0.3-alpine")).withExposedPorts(6379);
+      new GenericContainer<>(DockerImageName.parse("redis:7.2.4")).withExposedPorts(6379);
 
   private static SaslPlaintextKafkaContainer container;
   private TopicManager topicManager;

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -158,6 +158,6 @@ public class RedisBackendIT {
     String content = jedis.get(bucket);
     assertThat(content)
         .contains(
-            "\"topics\" : [ \"testTopicCreation.project.topicB\", \"testTopicCreation.project.topicA\" ]");
+            "\"topics\" : [\n    \"testTopicCreation.project.topicB\",\n    \"testTopicCreation.project.topicA\"\n  ]");
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ConnectContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ConnectContainer.java
@@ -8,7 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 public class ConnectContainer extends GenericContainer<ConnectContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =
-      DockerImageName.parse("confluentinc/cp-kafka-connect").withTag("7.5.0");
+      DockerImageName.parse("confluentinc/cp-kafka-connect").withTag("7.6.0");
 
   private static int CONNECT_PORT = 8083;
   private static int CONNECT_SSL_PORT = 8084;

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
@@ -17,7 +17,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 
 public final class ContainerTestUtils {
 
-  static final String DEFAULT_CP_KAFKA_VERSION = "7.5.0";
+  static final String DEFAULT_CP_KAFKA_VERSION = "7.6.0";
 
   private ContainerTestUtils() {}
 

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/SchemaRegistryContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/SchemaRegistryContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =
-      DockerImageName.parse("confluentinc/cp-schema-registry").withTag("7.5.0");
+      DockerImageName.parse("confluentinc/cp-schema-registry").withTag("7.6.0");
 
   public static final int SR_PORT = 8081;
 


### PR DESCRIPTION
This is a "While you were gone, take 2".

* Updates certain GitHub actions to get rid of a lot of warnings.
* Updates most dependencies to the most recent version.
* When pretty-printing JSON, split arrays in one entry per line. This makes it much easier to spot differences in `.cluster-state`.
* Display the warning for disabled remote state verification just once.
* Make it possible to disable warnings printed when projects contain no topics.
* Make it possible to disable warnings printed when streams have no writers.

~~This PR is one commit behind `master`, since [the most recently merged contribution](https://github.com/kafka-ops/julie/pull/581) breaks [the unit tests](https://github.com/kafka-ops/julie/actions/runs/7743200322/job/21114078917#step:5:1176). (Maybe revert it to have unit tests work again.)~~
